### PR TITLE
Fix division by zero for empty DWF

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculator.java
@@ -214,8 +214,9 @@ class AmbientMemoryFootprintCalculator {
             }
 
             if (evaluationSettings.isVerbose()) {
+                long average = (numResources > 0) ? (maxTotal / numResources) : 0;
                 System.out.printf("Resource count %s average size %s max size %s\n", numResources,
-                        maxTotal / numResources, maxResourceSize);
+                        average, maxResourceSize);
             }
 
             return maxTotal;


### PR DESCRIPTION
If the watch face is empty, we could get a `java.lang.ArithmeticException: / by zero` exception
