### PR TITLE
Change the assumption that there's always at least one ambient layer

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculator.java
@@ -118,11 +118,6 @@ class AmbientMemoryFootprintCalculator {
                 perConfigurationDynamicResources.computeMaximumResourceUsage(
                         visitor.optionResources);
 
-        // There's always at least one layer, even if all the Part* nodes are hidden.
-        if (visitor.numLayers == 0) {
-            visitor.numLayers = 1;
-        }
-
         // In V1 we support a maximum of 2 layers and 2 clocks.
         if (evaluationSettings.applyV1OffloadLimitations()) {
             visitor.numLayers = min(visitor.numLayers, 2);


### PR DESCRIPTION
At Samsung's request, remove the logic that assumed there is always at least one layer needed for ambient memory calculations.