### PR TITLE
Add git hash to the jar's manifest file

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -25,11 +25,15 @@ jobs:
         java-version: '17'
         distribution: 'corretto'
         architecture: 'x64'
+    - name: Get project hash
+      run: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "git_hash=$git_hash" >> $GITHUB_ENV
     - name: Build memory-footprint.jar
       uses: gradle/gradle-build-action@v2.4.2
       with:
         gradle-version: 8.4
-        arguments: -p play-validations memory-footprint:jar
+        arguments: -p play-validations memory-footprint:jar -Dmemory-footprint.git_hash=${{ env.git_hash }} -Dmemory-footprint.version=latest
     - name: Release memory-footprint.jar
       uses: "marvinpinto/action-automatic-releases@latest"
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,8 +30,12 @@ jobs:
         java-version: '17'
         distribution: 'corretto'
         architecture: 'x64'
+    - name: Get project hash
+      run: |
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "git_hash=$git_hash" >> $GITHUB_ENV
     - name: Build memory-footprint.jar
       uses: gradle/gradle-build-action@v2.4.2
       with:
         gradle-version: 8.4
-        arguments: -p play-validations memory-footprint:jar
+        arguments: -p play-validations memory-footprint:jar -Dmemory-footprint.git_hash=${{ env.git_hash }}

--- a/play-validations/memory-footprint/build.gradle
+++ b/play-validations/memory-footprint/build.gradle
@@ -46,6 +46,14 @@ jar {
 
     manifest {
         attributes "Main-Class": "com.google.wear.watchface.dfx.memory.ResourceMemoryEvaluator"
+        // Use `gradle :memory-footprint:jar -Dmemory-footprint.git_hash=$(git rev-parse --short HEAD)` to store
+        // the current build's hash in the manifest file.
+        if(System.getProperty("memory-footprint.git_hash")) {
+          attributes "Git-Hash": System.getProperty("memory-footprint.git_hash")
+        }
+        if(System.getProperty("memory-footprint.version")) {
+          attributes "Version": System.getProperty("memory-footprint.version")
+        }
     }
 
     from {


### PR DESCRIPTION
By inspecting META-INF/MANIFEST.MF we'll be able to see which version of the jar is being used. Subsequently, we'll add a command line option to actually print it out.