### PR TITLE
Enable xml validation

### DIFF
--- a/play-validations/memory-footprint/build.gradle
+++ b/play-validations/memory-footprint/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'com.google.mug:mug-guava:6.6'
     implementation 'commons-cli:commons-cli:1.5.0'
+    implementation project(':validator')
 }
 
 compileJava {
@@ -65,6 +66,12 @@ jar {
 
 artifacts {
     executableJar(jar)
+}
+
+afterEvaluate {
+    tasks.named("jar") {
+        dependsOn(":validator:jar")
+    }
 }
 
 java {

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
@@ -21,7 +21,7 @@ import static com.google.wear.watchface.dfx.memory.MemoryFootprint.toMB;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-//import com.samsung.watchface.WatchFaceXmlValidator;
+import com.samsung.watchface.WatchFaceXmlValidator;
 
 import org.w3c.dom.Document;
 
@@ -148,15 +148,15 @@ public class ResourceMemoryEvaluator {
      * @throws TestFailedException if the watch face does not comply to the format version.
      */
     private static void validateFormat(WatchFaceData watchFaceData, String watchFaceFormatVersion) {
-        //WatchFaceXmlValidator xmlValidator = new WatchFaceXmlValidator();
-        //for (Document watchFaceDocument : watchFaceData.watchFaceDocuments) {
-        //    boolean documentHasValidSchema =
-        //            xmlValidator.validate(watchFaceDocument, watchFaceFormatVersion);
-        //    if (!documentHasValidSchema) {
-        //        throw new TestFailedException(
-        //                "Watch Face has syntactic errors and cannot be parsed.");
-        //    }
-        //}
+        WatchFaceXmlValidator xmlValidator = new WatchFaceXmlValidator();
+        for (Document watchFaceDocument : watchFaceData.watchFaceDocuments) {
+           boolean documentHasValidSchema =
+                   xmlValidator.validate(watchFaceDocument, watchFaceFormatVersion);
+           if (!documentHasValidSchema) {
+               throw new TestFailedException(
+                       "Watch Face has syntactic errors and cannot be parsed.");
+           }
+        }
     }
 
     /**

--- a/play-validations/settings.gradle
+++ b/play-validations/settings.gradle
@@ -15,3 +15,5 @@
  */
 rootProject.name='play-validations'
 include ':memory-footprint'
+include ':validator'
+project(':validator').projectDir = new File('../third_party/wff/specification/validator')


### PR DESCRIPTION
XML validation within the memory-footprint tool was temporarily disabled while we were in the process of opensourcing the XSD specification. Now that everything is public, we can enable it again.