### PR TITLE
Adds Watch Face Format (WFF) v2 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Face Format to build both watch faces and watch face design tools.
 The [XSD specification][xsd-specs] provides you with the specification needed in
 order to build validation into your watch face creation tools and processes.
 
+There are different versions of the specification: The latest is version 2 which
+builds and expands on version 1. Different versions have different Wear OS
+version support. To understand the differences in capabilities and compatibility
+please [see this guide][wff-versioning].
+
 ## XSD Validator
 
 The [XSD validator][xsd-validator] is a tool that allows you to check whether
@@ -43,3 +48,4 @@ Watch Face Format is distributed under the Apache 2.0 license, see the
 [samples]: https://github.com/android/wear-os-samples/tree/main/WatchFaceFormat
 [xsd-specs]: third_party/wff/specification/documents/1/
 [xsd-validator]: third_party/wff/README.md
+[wff-versioning]: https://developer.android.com/training/wearables/wff/versions

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ order to build validation into your watch face creation tools and processes.
 There are different versions of the specification: The latest is version 2 which
 builds and expands on version 1. Different versions have different Wear OS
 version support. To understand the differences in capabilities and compatibility
-please [see this guide][wff-versioning].
+please [see this guide][wff-features].
 
 ## XSD Validator
 
@@ -48,4 +48,4 @@ Watch Face Format is distributed under the Apache 2.0 license, see the
 [samples]: https://github.com/android/wear-os-samples/tree/main/WatchFaceFormat
 [xsd-specs]: third_party/wff/specification/documents/1/
 [xsd-validator]: third_party/wff/README.md
-[wff-versioning]: https://developer.android.com/training/wearables/wff/versions
+[wff-features]: https://developer.android.com/training/wearables/wff/features

--- a/play-validations/README.md
+++ b/play-validations/README.md
@@ -39,7 +39,7 @@ in Google Play reviews, but these represent reasonable settings for evaluation:
 
 ```shell
 java -jar ./memory-footprint.jar --watch-face MyWatchFace.apk \
-  --schema-version 1 \
+  --schema-version 2 \
   --ambient-limit-mb 10 \
   --active-limit-mb 100 \
   --apply-v1-offload-limitations \

--- a/third_party/wff/README.md
+++ b/third_party/wff/README.md
@@ -6,6 +6,10 @@ The watch face format specifcation allows you to validate your watch faces and
 operation of watch face generating tools. The specification is  
 [provided as XSD files][xsd-files].
 
+There are different versions of the specification, which have different
+capabilities and compatibilities. Please see [this guide][wff-versions] for more
+details.
+
 ## Format validator
 
 In addition to the XSD files, a validator is provided that can be used to check
@@ -18,20 +22,21 @@ cd third_party/wff
 ./gradlew :specification:validator:build
 ```
 
-The resulting JAR file can then be found at: `specification/validator/build/libs/dwf-format-1-validator-1.0.jar`
+The resulting JAR file can then be found at: `specification/validator/build/libs/dwf-format-2-validator-1.0.jar`
 
 ### Usage
 
 To check whether a watch face is valid, invoke the validator as follows:
 
 ```shell
-java -jar dwf-format-1-validator-1.0.jar <format-version> <any options> <your-watchface.xml> <more-watchface.xml>
+java -jar dwf-format-2-validator-1.0.jar <format-version> <any options> <your-watchface.xml> <more-watchface.xml>
 ```
 
 For example:
 
 ```shell
-java -jar dwf-format-1-validator-1.0.jar 1 ~/MyWatchface/res/raw/watchface.xml
+java -jar dwf-format-2-validator-1.0.jar 2 ~/MyWatchface/res/raw/watchface.xml
 ```
 
 [xsd-files]: specification/documents/1
+[wff-versions]: https://developer.android.com/training/wearables/wff/versions

--- a/third_party/wff/README.md
+++ b/third_party/wff/README.md
@@ -7,7 +7,7 @@ operation of watch face generating tools. The specification is
 [provided as XSD files][xsd-files].
 
 There are different versions of the specification, which have different
-capabilities and compatibilities. Please see [this guide][wff-versions] for more
+capabilities and compatibilities. Please see [this guide][wff-features] for more
 details.
 
 ## Format validator
@@ -39,4 +39,4 @@ java -jar dwf-format-2-validator-1.0.jar 2 ~/MyWatchface/res/raw/watchface.xml
 ```
 
 [xsd-files]: specification/documents/1
-[wff-versions]: https://developer.android.com/training/wearables/wff/versions
+[wff-features]: https://developer.android.com/training/wearables/wff/features

--- a/third_party/wff/specification/documents/2/bitmapFontsElement.xsd
+++ b/third_party/wff/specification/documents/2/bitmapFontsElement.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common/attributes/geometricAttributes.xsd"/>
+
+  <xs:complexType name="_bitmapImportDataType">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="resource" type="xs:string" use="required"/>
+    <xs:attributeGroup ref="sizeAttributesRequired"/>
+    <xs:attributeGroup ref="margins"/>
+  </xs:complexType>
+
+  <xs:element name="BitmapFonts">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation>
+          User-defined bitmap fonts can be declared in this scope.
+        </xs:documentation>
+      </xs:annotation>
+
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="BitmapFont" minOccurs="1" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                User-defined bitmap font can be declared with this element.
+                Put the name for the family attribute in the font element.
+              </xs:documentation>
+            </xs:annotation>
+
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+              <xs:choice>
+                <xs:element name="Character" type="_bitmapImportDataType"/>
+                <xs:element name="Word" type="_bitmapImportDataType"/>
+              </xs:choice>
+            </xs:choice>
+
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+
+          <xs:unique name="Validation.Unique.BitmapFont.Child.Name">
+            <xs:selector xpath="*"/>
+            <xs:field xpath="@name"/>
+          </xs:unique>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/clock/analogClock.xsd
+++ b/third_party/wff/specification/documents/2/clock/analogClock.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../group/renderModeType.xsd"/>
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd" />
+  <xs:include schemaLocation="hourHand.xsd"/>
+  <xs:include schemaLocation="minuteHand.xsd"/>
+  <xs:include schemaLocation="secondHand.xsd"/>
+
+  <xs:element name="AnalogClock">
+    <xs:annotation>
+      <xs:documentation>
+        AnalogClock is a container that represents a traditional clock with
+        rotating hands.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="HourHand" minOccurs="0" maxOccurs="2"/>
+        <xs:element ref="MinuteHand" minOccurs="0" maxOccurs="2"/>
+        <xs:element ref="SecondHand" minOccurs="0" maxOccurs="2"/>
+        <xs:element ref="Localization" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute name="angle" type="angleType"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="scaleX" type='xs:float'/>
+      <xs:attribute name="scaleY" type='xs:float'/>
+      <xs:attribute name="renderMode" type="renderModeType" default="SOURCE"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/clock/digitalClock.xsd
+++ b/third_party/wff/specification/documents/2/clock/digitalClock.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../group/renderModeType.xsd"/>
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../userConfiguration/listConfigurationElement.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd" />
+  <xs:include schemaLocation="timeText.xsd"/>
+
+  <xs:element name="DigitalClock">
+    <xs:annotation>
+      <xs:documentation>
+        DigitalClock is a container for text-based formatted time.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Localization" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="TimeText" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute name="angle" type="angleType"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="scaleX" type='xs:float'/>
+      <xs:attribute name="scaleY" type='xs:float'/>
+      <xs:attribute name="renderMode" type="renderModeType" default="SOURCE"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/clock/hourHand.xsd
+++ b/third_party/wff/specification/documents/2/clock/hourHand.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../userConfiguration/listConfigurationElement.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd" />
+
+  <xs:element name="HourHand">
+    <xs:annotation>
+      <xs:documentation>
+        A image that represents an hour hand, it rotates 360 degree in 12 hours.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:choice>
+
+      <xs:attribute name="resource" type="xs:string" use="required"/>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/clock/minuteHand.xsd
+++ b/third_party/wff/specification/documents/2/clock/minuteHand.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../userConfiguration/listConfigurationElement.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd" />
+
+  <xs:element name="MinuteHand">
+    <xs:annotation>
+      <xs:documentation>
+        A image that represent a minute hand, it rotates 360 degree in 1 hour.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:choice>
+
+      <xs:attribute name="resource" type="xs:string" use="required"/>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/clock/secondHand.xsd
+++ b/third_party/wff/specification/documents/2/clock/secondHand.xsd
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../userConfiguration/listConfigurationElement.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd" />
+
+  <xs:element name="SecondHand">
+    <xs:annotation>
+      <xs:documentation>
+        A image that represents a second hand, it rotates 360 degree in 1 minute.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded" />
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element ref="Sweep"/>
+          <xs:element ref="Tick"/>
+        </xs:choice>
+      </xs:sequence>
+
+      <xs:attribute name="resource" type="xs:string" use="required"/>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="Sweep">
+    <xs:annotation>
+    <xs:documentation>
+      Definition of second hand movement.
+      The angle of the second hand will be updated by the given frequency for one second.
+
+      SYNC_TO_DEVICE means that the angle is updated smoothly as allowed by the device. (Since V2)
+    </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="frequency" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="10"/>
+            <xs:enumeration value="15"/>
+            <xs:enumeration value="SYNC_TO_DEVICE" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="Tick">
+    <xs:annotation>
+      <xs:documentation>
+        Definition of second hand movement. It has 2 attributes below.
+
+        Strength means intensity that exceeded the final value.
+        0.5 : has 125% peek value of the final value.
+        1.0 : has 200% peek value of the final value.
+
+        Duration means how long the animation is interpolated.
+        0.2 :   0 ~ 200 (ms) - interpolated value by given strength and time
+              200 ~ 800 (ms) - no movement.
+
+        These are used as x1, y1 parameters of the cubic bezier curve.
+        cubic-bezier((duration - 0.033) / duration, 1 + strength * 2, 1, 1)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="strength" type="xs:float" use="required"/>
+      <xs:attribute name="duration" type="xs:float" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/clock/timeText.xsd
+++ b/third_party/wff/specification/documents/2/clock/timeText.xsd
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../group/renderModeType.xsd"/>
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd" />
+  <xs:include schemaLocation="../common/attributes/colorAttributes.xsd"/>
+  <xs:include schemaLocation="../common/attributes/angleType.xsd"/>
+  <xs:include schemaLocation="../common/attributes/alignmentAttribute.xsd"/>
+
+  <xs:element name="TimeText">
+    <xs:annotation>
+      <xs:documentation>
+        TimeText renders the time within the DigitalClock container.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:choice minOccurs="0" maxOccurs="1">
+          <xs:element name="BitmapFont">
+            <xs:complexType mixed="true">
+              <xs:attribute name="family" type="xs:string" use="required"/>
+              <xs:attribute name="size" type="xs:float" use="required"/>
+              <xs:attribute name="color" type="colorAttributeType" default="#FFFFFF"/>
+            </xs:complexType>
+          </xs:element>
+
+          <xs:element name="Font">
+            <xs:complexType mixed="true">
+              <xs:attribute name="family" type="xs:string" use="required"/>
+              <xs:attribute name="size" type="xs:float" use="required"/>
+              <xs:attribute name="color" type="colorAttributeType" default="#FFFFFF"/>
+              <xs:attribute name="slant" default="NORMAL">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="NORMAL"/>
+                    <xs:enumeration value="ITALIC"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:attribute>
+              <xs:attribute name="width" default="NORMAL">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="ULTRA_CONDENSED"/>
+                    <xs:enumeration value="EXTRA_CONDENSED"/>
+                    <xs:enumeration value="CONDENSED"/>
+                    <xs:enumeration value="SEMI_CONDENSED"/>
+                    <xs:enumeration value="NORMAL"/>
+                    <xs:enumeration value="SEMI_EXPANDED"/>
+                    <xs:enumeration value="EXPANDED"/>
+                    <xs:enumeration value="EXTRA_EXPANDED"/>
+                    <xs:enumeration value="ULTRA_EXPANDED"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:attribute>
+              <xs:attribute name="weight" default="NORMAL">
+                <xs:simpleType>
+                  <!--https://developer.android.com/reference/android/graphics/Typeface#create(android.graphics.Typeface,%20int,%20boolean)-->
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="THIN"/>
+                    <xs:enumeration value="ULTRA_LIGHT"/>
+                    <xs:enumeration value="EXTRA_LIGHT"/>
+                    <xs:enumeration value="LIGHT"/>
+                    <xs:enumeration value="NORMAL"/>
+                    <xs:enumeration value="MEDIUM"/>
+                    <xs:enumeration value="SEMI_BOLD"/>
+                    <xs:enumeration value="ULTRA_BOLD"/>
+                    <xs:enumeration value="EXTRA_BOLD"/>
+                    <xs:enumeration value="BLACK"/>
+                    <xs:enumeration value="EXTRA_BLACK"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:attribute>
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+
+      <xs:attribute name="format" type="timeFormatType" use="required"/>
+      <xs:attribute name="hourFormat" type="hourFormatType" default="SYNC_TO_DEVICE"/>
+      <xs:attribute ref="align"/>
+
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute name="angle" type="angleType"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="hourFormatType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="12"/>
+      <xs:enumeration value="24"/>
+      <xs:enumeration value="SYNC_TO_DEVICE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="timeFormatType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="h{2}\_(1\d|1)|m{2}\_(1\d|1)|s{2}\_(1\d|1)|((h{1,2})\:m{1,2}\:s{1,2}|(h{1,2})\:m{1,2})|(h{1,2})|m{1,2}|s{1,2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/animationElement.xsd
+++ b/third_party/wff/specification/documents/2/common/animationElement.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="attributes/primitiveListTypes.xsd"/>
+
+  <xs:element name="Animation">
+    <xs:annotation>
+      <xs:documentation>
+        Animation for parent element.
+        Use "ANIMATION_VALUE" from the parent element's arithmetic attribute.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="interpolation" default="LINEAR">
+        <xs:annotation>
+          <xs:documentation>
+            Interpolation method. Default is linear.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="LINEAR"/>
+            <xs:enumeration value="EASE_IN"/>
+            <xs:enumeration value="EASE_OUT"/>
+            <xs:enumeration value="EASE_IN_OUT"/>
+            <xs:enumeration value="OVERSHOOT"/>
+            <xs:enumeration value="CUBIC_BEZIER"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <!-- Controls attribute is meaningful only when interpolation type is CUBIC_BEZIER -->
+      <xs:attribute name="controls" default="0.5 0.5 0.5 0.5" type="vector4fType"/>
+      <xs:attribute name="angleDirection" default="NONE">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="CLOCKWISE"/>
+            <xs:enumeration value="COUNTER_CLOCKWISE"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="repeat" default="0">
+        <xs:annotation>
+          <xs:documentation>
+            Sets how many times the animation should be repeated. If the repeat
+            count is 0, the animation is never repeated. If the repeat count is
+            -1 then the animation will loop indefinitely.
+            The repeat count is 0 by default.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:int">
+            <xs:minInclusive value="-1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <xs:attribute name="fps" type="xs:int" default="15"/>
+      <xs:attribute name="duration" type="xs:float" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Duration in seconds
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/alignmentAttribute.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/alignmentAttribute.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="align" default="CENTER">
+    <xs:annotation>
+      <xs:documentation>
+        Alignment of the tag.
+        Default is START.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="START"/>
+        <xs:enumeration value="CENTER"/>
+        <xs:enumeration value="END"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/angleType.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/angleType.xsd
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="arithmeticExpressionType.xsd"/>
+
+  <xs:simpleType name="_angleTypeValuePreferences">
+    <xs:restriction base="xs:float">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="180"/>
+      <xs:enumeration value="360"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="angleType">
+    <xs:annotation>
+      <xs:documentation>
+        Angle in degrees.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="_angleTypeValuePreferences xs:float"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="angleExpressionType">
+    <xs:annotation>
+      <xs:documentation>
+        Angle in degrees represented by expression.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="_angleTypeValuePreferences arithmeticExpressionType"/>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="angleAttributeGroupRequired">
+    <xs:annotation>
+      <xs:documentation>
+        Start angle and end angle in degrees.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="startAngle" type="angleType" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Start angle in degrees.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="endAngle" type="angleType" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          End angle in degrees.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="angleExpressionAttributeGroupRequired">
+    <xs:annotation>
+      <xs:documentation>
+        Start angle and end angle represented by expression.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="startAngle" type="angleExpressionType" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Start angle in degrees represented by expression.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="endAngle" type="angleExpressionType" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          End angle in degrees represented by expression.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/arithmeticExpressionType.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/arithmeticExpressionType.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="sourceType.xsd"/>
+
+  <xs:simpleType name="_anyExpressionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="["/>
+      <xs:enumeration value="]"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="_functionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="round()"/>
+      <xs:enumeration value="floor()"/>
+      <xs:enumeration value="ceil()"/>
+      <xs:enumeration value="fract()"/>
+      <xs:enumeration value="sin()"/>
+      <xs:enumeration value="cos()"/>
+      <xs:enumeration value="tan()"/>
+      <xs:enumeration value="asin()"/>
+      <xs:enumeration value="acos()"/>
+      <xs:enumeration value="atan()"/>
+      <xs:enumeration value="abs()"/>
+      <xs:enumeration value="clamp(,,)"/>
+      <xs:enumeration value="rand(,)"/>
+      <xs:enumeration value="log()"/>
+      <xs:enumeration value="log2()"/>
+      <xs:enumeration value="log10()"/>
+      <xs:enumeration value="sqrt()"/>
+      <xs:enumeration value="cbrt()"/>
+      <xs:enumeration value="exp()"/>
+      <xs:enumeration value="expm1()"/>
+      <xs:enumeration value="deg()"/>
+      <xs:enumeration value="rad()"/>
+      <xs:enumeration value="pow(,)"/>
+      <xs:enumeration value="numberFormat(,)"/>
+      <xs:enumeration value="icuText()"/>
+      <xs:enumeration value="icuBestText()"/>
+      <xs:enumeration value="icuText(,)"/>
+      <xs:enumeration value="icuBestText(,)"/>
+      <xs:enumeration value="subText(,,)"/>
+      <xs:enumeration value="textLength()"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="_operatorType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="+"/>
+      <xs:enumeration value="-"/>
+      <xs:enumeration value="*"/>
+      <xs:enumeration value="/"/>
+      <xs:enumeration value="%"/>
+      <xs:enumeration value="~"/>
+      <xs:enumeration value="!"/>
+      <xs:enumeration value="|"/>
+      <xs:enumeration value="||"/>
+      <xs:enumeration value="&amp;"/>
+      <xs:enumeration value="&amp;&amp;"/>
+
+      <xs:enumeration value="("/>
+      <xs:enumeration value=")"/>
+      <xs:enumeration value=">"/>
+      <xs:enumeration value=">="/>
+      <xs:enumeration value="?"/>
+      <xs:enumeration value=":"/>
+      <xs:enumeration value="=="/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="_arithmeticType">
+    <xs:union memberTypes="sourceType _operatorType _functionType _anyExpressionType xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="_arithmeticListType">
+    <xs:list itemType="_arithmeticType"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="_gyroArithmeticType">
+    <xs:union memberTypes="sensorSourceType _operatorType _functionType _anyExpressionType xs:string"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="_gyroArithmeticListType">
+    <xs:list itemType="_gyroArithmeticType"/>
+  </xs:simpleType>
+
+  <!-- Arithmetic expression by attribute -->
+  <xs:simpleType name="arithmeticExpressionType">
+    <xs:annotation>
+      <xs:documentation>
+        Arithmetic expression with algebraic source expression.
+        Use CDATA tag if necessary.
+        ex. [SECOND] * 6 + 180
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="_arithmeticType _arithmeticListType"/>
+  </xs:simpleType>
+
+  <!-- Arithmetic expression by attribute -->
+  <xs:simpleType name="gyroArithmeticExpressionType">
+    <xs:annotation>
+      <xs:documentation>
+        Arithmetic expression with algebraic source expression for gyro effect.
+        Use CDATA tag if necessary.
+        ex. (5/90)* clamp([ACCELEROMETER_ANGLE_X], 0, 90) + (-5/-90)* clamp([ACCELEROMETER_ANGLE_X], -90, 0)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="_gyroArithmeticType _gyroArithmeticListType"/>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/calendarAttribute.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/calendarAttribute.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:attribute name="calendar" default="GREGORIAN">
+    <xs:simpleType>
+      <!-- https://developer.android.com/reference/android/icu/util/Calendar -->
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="BUDDHIST"/>
+        <xs:enumeration value="CHINESE"/>
+        <xs:enumeration value="COPTIC"/>
+        <xs:enumeration value="DANGI"/>
+        <xs:enumeration value="ETHIOPIC"/>
+        <xs:enumeration value="ETHIOPIC_AMETE_ALEM"/>
+        <xs:enumeration value="GREGORIAN"/>
+        <xs:enumeration value="HEBREW"/>
+        <xs:enumeration value="INDIAN"/>
+        <xs:enumeration value="ISLAMIC"/>
+        <xs:enumeration value="ISLAMIC_CIVIL"/>
+        <xs:enumeration value="ISLAMIC_UMALQURA"/>
+        <xs:enumeration value="JAPANESE"/>
+        <xs:enumeration value="PERSIAN"/>
+        <xs:enumeration value="ROC"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:attribute>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/colorAttributes.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/colorAttributes.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="unsignedCharacterType.xsd"/>
+  <xs:include schemaLocation="arithmeticExpressionType.xsd"/>
+
+  <xs:simpleType name="_colorValuePreferences">
+    <xs:restriction base="unsignedCharacterType">
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="128"/>
+      <xs:enumeration value="255"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="_colorComponentType">
+    <xs:union memberTypes="_colorValuePreferences unsignedCharacterType"/>
+  </xs:simpleType>
+
+  <xs:attribute name="alpha" type="_colorComponentType"/>
+
+  <xs:simpleType name="argbHexadecimalType">
+    <xs:annotation>
+      <xs:documentation>
+        Hexadecimal color code: #AARRGGBB or #RRGGBB
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6})"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="colorAttributeType">
+    <xs:annotation>
+      <xs:documentation>
+        Hexadecimal color code: #AARRGGBB or #RRGGBB
+        or
+        Data source representing a color: CONFIGURATION.themeColor.1
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\[[A-Z0-9]+(\.\w+)*\]|#([A-Fa-f0-9]{6,8})"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/dimensionType.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/dimensionType.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="dimensionType">
+    <xs:annotation>
+      <xs:documentation>
+        Integer-based dimension.
+        The dimension is a relative value corresponding to the width and height of the WatchFace.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="floatDimensionType">
+    <xs:annotation>
+      <xs:documentation>
+        Float-based dimension.
+        The dimension is a relative value corresponding to the width and height of the WatchFace.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:float"/>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/geometricAttributes.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/geometricAttributes.xsd
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="dimensionType.xsd"/>
+
+  <xs:attribute name="x" type="dimensionType">
+    <xs:annotation>
+      <xs:documentation>
+        Relative starting point (x,y) of the element on the screen.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attribute name="y" type="dimensionType">
+    <xs:annotation>
+      <xs:documentation>
+        Relative starting point (x,y) of the element on the screen.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attribute name="width" type="dimensionType">
+    <xs:annotation>
+      <xs:documentation>
+        Size of the element (width, height)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attribute name="height" type="dimensionType">
+    <xs:annotation>
+      <xs:documentation>
+        Size of the element (width, height)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  
+  <xs:attribute name="marginLeft" type="xs:float" default="0">
+    <xs:annotation>
+      <xs:documentation>
+        A margin to be applied to the left of the object.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  
+  <xs:attribute name="marginTop" type="xs:float" default="0">
+    <xs:annotation>
+      <xs:documentation>
+        A margin to be applied to the top of the object.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attribute name="marginRight" type="xs:float" default="0">
+    <xs:annotation>
+      <xs:documentation>
+        A margin to be applied to the right of the object.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attribute name="marginBottom" type="xs:float" default="0">
+    <xs:annotation>
+      <xs:documentation>
+        A margin to be applied to the bottom of the object.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <!-- Attribute groups for convenience. -->
+
+  <xs:attributeGroup name="positionAttributes">
+    <xs:annotation>
+      <xs:documentation>
+        Geometry data. Relative starting position of (x, y) the part on the screen.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:attribute ref="x"/>
+    <xs:attribute ref="y"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="sizeAttributes">
+    <xs:annotation>
+      <xs:documentation>
+        Geometry data. size of (width, height).
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:attribute ref="width"/>
+    <xs:attribute ref="height"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="positionAttributesRequired">
+    <xs:annotation>
+      <xs:documentation>
+        Geometry data. Relative starting position of (x, y) the part on the screen.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:attribute ref="x" use="required"/>
+    <xs:attribute ref="y" use="required"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="sizeAttributesRequired">
+    <xs:annotation>
+      <xs:documentation>
+        Geometry data. size of (width, height).
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:attribute ref="width" use="required"/>
+    <xs:attribute ref="height" use="required"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="geometricAttributes">
+    <xs:annotation>
+      <xs:documentation>
+        Geometry data.
+        (x, y) is relative start position on screen with the size of (width, height).
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:attributeGroup ref="positionAttributes"/>
+    <xs:attributeGroup ref="sizeAttributes"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="geometricAttributesRequired">
+    <xs:annotation>
+      <xs:documentation>
+        Geometry data.
+        (x, y) is relative start position on screen with the size of (width, height).
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:attributeGroup ref="positionAttributesRequired"/>
+    <xs:attributeGroup ref="sizeAttributesRequired"/>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="margins">
+    <xs:annotation>
+      <xs:documentation>
+        A set of margins to apply to the element. The set of margins, 
+        (marginLeft, marginTop, marginRight, marginBottom), are floating-point 
+        values in pixels applied to the object's bounds, to allow positioning of
+        cropped images.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:attribute ref="marginLeft"/>
+    <xs:attribute ref="marginTop"/>
+    <xs:attribute ref="marginRight"/>
+    <xs:attribute ref="marginBottom"/>
+  </xs:attributeGroup>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/normalizedType.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/normalizedType.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- TODO hide normalizedValuePreferences normalizedValueType -->
+  <xs:simpleType name="_normalizedValuePreferences">
+    <xs:restriction base="_normalizedValueType">
+      <xs:enumeration value="0.0"/>
+      <xs:enumeration value="0.5"/>
+      <xs:enumeration value="1.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="_normalizedValueType">
+    <xs:restriction base="xs:float">
+      <xs:minInclusive value="0.0"/>
+      <xs:maxInclusive value="1.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="normalizedType">
+    <xs:annotation>
+      <xs:documentation>
+        Normalized value to [0.0, 1.0]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="_normalizedValuePreferences _normalizedValueType"/>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/primitiveListTypes.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/primitiveListTypes.xsd
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:include schemaLocation="colorAttributes.xsd"/>
+
+	<xs:simpleType name="vector4fType">
+		<xs:annotation>
+			<xs:documentation>
+				Vector type for 4 floats
+				e.g., "0.1 0.2 0.3 0.4"
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="floatListType">
+			<xs:minLength value="4"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="vector3fType">
+		<xs:annotation>
+			<xs:documentation>
+				Vector type for 3 floats
+				e.g., "0.1 0.2 0.3"
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="floatListType">
+			<xs:minLength value="3"/>
+			<xs:maxLength value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="floatListType">
+		<xs:annotation>
+			<xs:documentation>
+				List type for floats
+				e.g., "0.1 0.2 0.3 0.4 0.5 0.6 0.7 ..."
+			</xs:documentation>
+		</xs:annotation>
+		<xs:list itemType="xs:float"/>
+	</xs:simpleType>
+
+	<xs:simpleType name="vector4iType">
+		<xs:annotation>
+			<xs:documentation>
+				Vector type for 4 integers
+				e.g., "1 2 3 4"
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="intListType">
+			<xs:minLength value="4"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="vector3iType">
+		<xs:annotation>
+			<xs:documentation>
+				Vector type for 3 integers
+				e.g., "1 2 3"
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="intListType">
+			<xs:minLength value="3"/>
+			<xs:maxLength value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="intListType">
+		<xs:annotation>
+			<xs:documentation>
+				List type for integers
+				e.g., "1 2 3 4 5 6 7 ..."
+			</xs:documentation>
+		</xs:annotation>
+		<xs:list itemType="xs:int"/>
+	</xs:simpleType>
+
+	<xs:simpleType name="vector4sType">
+		<xs:annotation>
+			<xs:documentation>
+				Vector type for 4 strings
+				e.g., "abc def ghi jkl"
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="stringListType">
+			<xs:minLength value="4"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="vector3sType">
+		<xs:annotation>
+			<xs:documentation>
+				Vector type for 3 strings
+				e.g., "abc def ghi"
+			</xs:documentation>
+		</xs:annotation>
+
+		<xs:restriction base="stringListType">
+			<xs:minLength value="3"/>
+			<xs:maxLength value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="stringListType">
+		<xs:annotation>
+			<xs:documentation>
+				List type for strings
+				e.g., "abc def ghi jkl mno pqr student ..."
+			</xs:documentation>
+		</xs:annotation>
+		<xs:list itemType="xs:string"/>
+	</xs:simpleType>
+
+	<xs:simpleType name="userStyleColorOptionType">
+		<xs:annotation>
+			<xs:documentation>
+				List type for hexadecimal colors
+				e.g., "#FF00FF #FFFFFF #80FF1234"
+			</xs:documentation>
+		</xs:annotation>
+
+		<xs:restriction base="colorListType">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="5"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="colorListType">
+		<xs:annotation>
+			<xs:documentation>
+				List type for hexadecimal colors
+				e.g., "#FF00FF #FFFFFF #80FF1234 #12345678 #123456 ..."
+			</xs:documentation>
+		</xs:annotation>
+		<xs:list itemType="argbHexadecimalType"/>
+	</xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/sourceType.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/sourceType.xsd
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- Some specific elements may want to restrict the attribute's value. -->
+
+  <xs:simpleType name="timeUnitSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources related to time unit
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="MILLISECOND"/>
+      <xs:enumeration value="SECOND"/>
+      <xs:enumeration value="SECOND_Z"/>
+      <xs:enumeration value="MINUTE"/>
+      <xs:enumeration value="MINUTE_Z"/>
+      <xs:enumeration value="AMPM_STATE"/>
+      <xs:enumeration value="DAY"/>
+      <xs:enumeration value="DAY_Z"/>
+      <xs:enumeration value="MONTH"/>
+      <xs:enumeration value="MONTH_Z"/>
+      <xs:enumeration value="MONTH_F"/>
+      <xs:enumeration value="MONTH_S"/>
+      <xs:enumeration value="YEAR"/>
+      <xs:enumeration value="YEAR_S"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="_timeSourceType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="UTC_TIMESTAMP"/>
+      <xs:enumeration value="SECOND_MILLISECOND"/>
+      <xs:enumeration value="SECONDS_IN_DAY"/>
+      <xs:enumeration value="MINUTE_SECOND"/>
+      <xs:enumeration value="HOUR_0_11"/>
+      <xs:enumeration value="HOUR_0_11_Z"/>
+      <xs:enumeration value="HOUR_0_11_MINUTE"/>
+      <xs:enumeration value="HOUR_1_12"/>
+      <xs:enumeration value="HOUR_1_12_Z"/>
+      <xs:enumeration value="HOUR_1_12_MINUTE"/>
+      <xs:enumeration value="HOUR_0_23"/>
+      <xs:enumeration value="HOUR_0_23_Z"/>
+      <xs:enumeration value="HOUR_0_23_MINUTE"/>
+      <xs:enumeration value="HOUR_1_24"/>
+      <xs:enumeration value="HOUR_1_24_Z"/>
+      <xs:enumeration value="HOUR_1_24_MINUTE"/>
+      <xs:enumeration value="DAY_HOUR"/>
+      <xs:enumeration value="DAY_0_30"/>
+      <xs:enumeration value="DAY_0_30_HOUR"/>
+      <xs:enumeration value="DAY_OF_YEAR"/>
+      <xs:enumeration value="DAY_OF_WEEK"/>
+      <xs:enumeration value="DAY_OF_WEEK_F"/>
+      <xs:enumeration value="DAY_OF_WEEK_S"/>
+      <xs:enumeration value="FIRST_DAY_OF_WEEK"/>
+      <xs:enumeration value="DAYS_IN_MONTH"/>
+      <xs:enumeration value="MONTH_DAY"/>
+      <xs:enumeration value="MONTH_0_11"/>
+      <xs:enumeration value="MONTH_0_11_DAY"/>
+      <xs:enumeration value="YEAR_MONTH"/>
+      <xs:enumeration value="YEAR_MONTH_DAY"/>
+      <xs:enumeration value="WEEK_IN_MONTH"/>
+      <xs:enumeration value="WEEK_IN_YEAR"/>
+      <xs:enumeration value="IS_24_HOUR_MODE"/>
+      <xs:enumeration value="IS_DAYLIGHT_SAVING_TIME"/>
+      <xs:enumeration value="TIMEZONE"/>
+      <xs:enumeration value="TIMEZONE_ABB"/>
+      <xs:enumeration value="TIMEZONE_ID"/>
+      <xs:enumeration value="TIMEZONE_OFFSET"/>
+      <xs:enumeration value="TIMEZONE_OFFSET_DST"/>
+      <xs:enumeration value="AMPM_POSITION"/>
+      <xs:enumeration value="AMPM_STRING"/>
+      <xs:enumeration value="AMPM_STRING_ENG"/>
+      <xs:enumeration value="AMPM_STRING_SHORT"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="timeSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources related to time and date
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="timeUnitSourceType _timeSourceType"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="languageSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources related to language
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="LANGUAGE_CODE"/>
+      <xs:enumeration value="LANGUAGE_COUNTRY_CODE"/>
+      <xs:enumeration value="LANGUAGE_LOCALE_NAME"/>
+      <xs:enumeration value="LANGUAGE_TEXT_DIRECTION"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="batterySourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources related to battery
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="BATTERY_PERCENT"/>
+      <xs:enumeration value="BATTERY_CHARGING_STATUS"/>
+      <xs:enumeration value="BATTERY_IS_LOW"/>
+      <xs:enumeration value="BATTERY_TEMPERATURE_CELSIUS"/>
+      <xs:enumeration value="BATTERY_TEMPERATURE_FAHRENHEIT"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="moonPhaseSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources related to moon phase
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="MOON_PHASE_POSITION"/>
+      <xs:enumeration value="MOON_PHASE_TYPE"/>
+      <xs:enumeration value="MOON_PHASE_TYPE_STRING"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="sensorSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources related to sensor
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ACCELEROMETER_IS_SUPPORTED"/>
+      <xs:enumeration value="ACCELEROMETER_X"/>
+      <xs:enumeration value="ACCELEROMETER_Y"/>
+      <xs:enumeration value="ACCELEROMETER_Z"/>
+      <xs:enumeration value="ACCELEROMETER_ANGLE_X"/>
+      <xs:enumeration value="ACCELEROMETER_ANGLE_Y"/>
+      <xs:enumeration value="ACCELEROMETER_ANGLE_Z"/>
+      <xs:enumeration value="ACCELEROMETER_ANGLE_XY"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="healthSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources related to health data
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="STEP_COUNT"/>
+      <xs:enumeration value="STEP_GOAL"/>
+      <xs:enumeration value="STEP_PERCENT"/>
+      <xs:enumeration value="HEART_RATE"/>
+      <xs:enumeration value="HEART_RATE_Z"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="notificationSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Sources of notification data
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="UNREAD_NOTIFICATION_COUNT"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="miscSourceType">
+    <xs:annotation>
+      <xs:documentation>
+        Miscellaneous sources
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SUPPORTED_FORMAT_VERSION"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="sourceType">
+    <xs:union
+        memberTypes="timeSourceType languageSourceType batterySourceType moonPhaseSourceType
+        sensorSourceType healthSourceType notificationSourceType miscSourceType"/>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/attributes/unsignedCharacterType.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/unsignedCharacterType.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="unsignedCharacterType">
+    <xs:annotation>
+      <xs:documentation>
+        <pre>
+          Unsigned character value in scope [0,255]
+        </pre>
+      </xs:documentation>
+    </xs:annotation>
+    <!-- xs:unsignedByte does not check minValue. Use this custom type instead -->
+    <xs:restriction base="xs:integer">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="255"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/booleanType.xsd
+++ b/third_party/wff/specification/documents/2/common/booleanType.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="attributes/geometricAttributes.xsd"/>
+
+  <xs:simpleType name="booleanType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="TRUE"/>
+      <xs:enumeration value="FALSE"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/circularDirectionType.xsd
+++ b/third_party/wff/specification/documents/2/common/circularDirectionType.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:simpleType name="circularDirectionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="CLOCKWISE"/>
+      <xs:enumeration value="COUNTER_CLOCKWISE"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/conditionElement.xsd
+++ b/third_party/wff/specification/documents/2/common/conditionElement.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="expressionsElement.xsd"/>
+  <xs:include schemaLocation="../group/groupElement.xsd"/>
+  <xs:include schemaLocation="../group/part/partElementGroup.xsd"/>
+  <xs:include schemaLocation="../clock/analogClock.xsd"/>
+  <xs:include schemaLocation="../clock/digitalClock.xsd"/>
+
+  <xs:group name="_CompareChild">
+    <xs:choice>
+      <xs:element ref="Group"/>
+      <xs:group ref="PartElementGroup"/>
+      <xs:element ref="Condition"/>
+      <xs:element ref="AnalogClock"/>
+      <xs:element ref="DigitalClock"/>
+    </xs:choice>
+  </xs:group>
+
+  <xs:element name="Condition">
+    <xs:annotation>
+      <xs:documentation>
+        The Condition element provides the ability to provide a list of options - Compare
+        Elements - each of which is evaluated against an expression, in turn. Only the first
+        successful Compare element is selected, the others are not rendered or enabled.
+        If none of the Compare elements evaluate successfully, the Default Element is shown.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Expressions" minOccurs="1"/>
+        <xs:element name="Compare" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+              <xs:group ref="_CompareChild"/>
+            </xs:choice>
+            <xs:attribute name="expression" type="arithmeticExpressionType" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Default" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              The Default element is enabled when no Compare element evaluates successfully.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+              <xs:group ref="_CompareChild"/>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+      </xs:all>
+    </xs:complexType>
+    <xs:key name="Validation.Unique.Condition.Expressions.Expression.name">
+      <xs:selector xpath="Expressions/Expression"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:keyref name="Validation.Reference.Condition.Compare.Expressions.Expression.name"
+               refer="Validation.Unique.Condition.Expressions.Expression.name">
+      <xs:selector xpath="Compare"/>
+      <xs:field xpath="@expression"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/eventTriggerType.xsd
+++ b/third_party/wff/specification/documents/2/common/eventTriggerType.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="eventTriggerType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="TAP"/>
+      <xs:enumeration value="ON_VISIBLE"/>
+      <xs:enumeration value="ON_NEXT_SECOND"/>
+      <xs:enumeration value="ON_NEXT_MINUTE"/>
+      <xs:enumeration value="ON_NEXT_HOUR"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="eventTriggerListType">
+    <xs:list itemType="eventTriggerType"/>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/expressionsElement.xsd
+++ b/third_party/wff/specification/documents/2/common/expressionsElement.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="attributes/arithmeticExpressionType.xsd"/>
+
+  <xs:element name="Expressions">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="Expression">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="arithmeticExpressionType">
+                <xs:attribute name="name" type="xs:string" use="required"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/launchElement.xsd
+++ b/third_party/wff/specification/documents/2/common/launchElement.xsd
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xs:simpleType name="_systemShortcutType">
+    <xs:annotation>
+      <xs:documentation>
+        System shortcuts
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ALARM"/>
+      <xs:enumeration value="BATTERY_STATUS"/>
+      <xs:enumeration value="CALENDAR"/>
+      <xs:enumeration value="MESSAGE"/>
+      <xs:enumeration value="MUSIC_PLAYER"/>
+      <xs:enumeration value="PHONE"/>
+      <xs:enumeration value="SETTINGS"/>
+      <xs:enumeration value="HEALTH_HEART_RATE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="launchTargetType">
+    <xs:union memberTypes="_systemShortcutType xs:string"/>
+  </xs:simpleType>
+
+  <xs:element name="Launch">
+    <xs:complexType>
+      <xs:attribute name="target" type="launchTargetType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/localizationElement.xsd
+++ b/third_party/wff/specification/documents/2/common/localizationElement.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="attributes/calendarAttribute.xsd"/>
+  <xs:include schemaLocation="attributes/primitiveListTypes.xsd"/>
+
+  <xs:element name="Localization">
+    <xs:annotation>
+      <xs:documentation>
+        The Localization is used to fix the date or time to a specific locale or timezone when
+        a parent node such as a part or group has an action related to the date or time.
+      </xs:documentation>
+    </xs:annotation>
+  <xs:complexType>
+    <xs:attribute name="timeZone" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          timezone
+          e.g., "Asia/Seoul" or "Europe/London"
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute ref="calendar"/>
+      <xs:attribute name="locales" type="stringListType">
+        <xs:annotation>
+          <xs:documentation>
+            if one of the given locales is matched to the system locale, it uses the matched locale,
+            otherwise, it uses the firstly added locale. If it is empty, it always follows the system
+            locale. e.g., "ko_KR" or "en_US en_GB fr_CH"
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/screenReaderElement.xsd
+++ b/third_party/wff/specification/documents/2/common/screenReaderElement.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="attributes/geometricAttributes.xsd"/>
+
+  <xs:element name="ScreenReader">
+    <xs:annotation>
+      <xs:documentation>
+        The user may turn on the talkback screen reader to interact with the watch face
+        with touch and voice feedback. ScreenReader can be attached to any group or
+        part to let user know how they work.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="Parameter">
+          <xs:complexType>
+            <xs:annotation>
+              <xs:documentation>
+                An argument of formatted string.
+              </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="expression" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="stringId" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/transform/gyroElements.xsd
+++ b/third_party/wff/specification/documents/2/common/transform/gyroElements.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../attributes/arithmeticExpressionType.xsd"/>
+
+  <xs:element name="Gyro">
+    <xs:annotation>
+      <xs:documentation>
+        The Gyro element adjusts some attributes of the parent Group or Part according to an expression
+        using gyro sensor data source.
+        ex. x="(5/90)* clamp([ACCELEROMETER_ANGLE_X], 0, 90) + (-5/-90)* clamp([ACCELEROMETER_ANGLE_X], -90, 0)"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="x" type="gyroArithmeticExpressionType"/>
+      <xs:attribute name="y" type="gyroArithmeticExpressionType"/>
+      <xs:attribute name="scaleX" type="gyroArithmeticExpressionType"/>
+      <xs:attribute name="scaleY" type="gyroArithmeticExpressionType"/>
+      <xs:attribute name="angle" type="gyroArithmeticExpressionType"/>
+      <xs:attribute name="alpha" type="gyroArithmeticExpressionType"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/transform/pivotType.xsd
+++ b/third_party/wff/specification/documents/2/common/transform/pivotType.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../attributes/normalizedType.xsd"/>
+
+  <xs:attributeGroup name="pivot2D">
+    <xs:attribute name="pivotX" type="xs:float">
+      <xs:annotation>
+        <xs:documentation>
+          Normalized floating pivot point of x in scope [0,1].
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="pivotY" type="xs:float">
+      <xs:annotation>
+        <xs:documentation>
+          Normalized floating pivot point of y in scope [0,1].
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/transform/transformElements.xsd
+++ b/third_party/wff/specification/documents/2/common/transform/transformElements.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../animationElement.xsd"/>
+  <xs:include schemaLocation="../attributes/arithmeticExpressionType.xsd"/>
+
+  <xs:element name="Transform">
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="Animation" minOccurs="0"/>
+      </xs:choice>
+      <xs:attribute name="target" type="xs:string" use="required"/>
+      <xs:attribute name="value" type="arithmeticExpressionType" use="required"/>
+      <xs:attribute name="mode" default="TO">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="TO"/>
+            <xs:enumeration value="BY"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/common/variant/variantElements.xsd
+++ b/third_party/wff/specification/documents/2/common/variant/variantElements.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../attributes/arithmeticExpressionType.xsd" />
+  <xs:element name="Variant">
+    <xs:complexType>
+      <xs:attribute name="target" type="xs:string" use="required" />
+      <xs:attribute name="value" type="arithmeticExpressionType" use="required" />
+      <xs:attribute name="mode" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="AMBIENT" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/complication/boundingElement.xsd
+++ b/third_party/wff/specification/documents/2/complication/boundingElement.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/attributes/angleType.xsd"/>
+  <xs:include schemaLocation="../common/booleanType.xsd"/>
+
+  <xs:element name="BoundingShape" abstract="true"/>
+
+  <xs:element name="BoundingBox" substitutionGroup="BoundingShape">
+    <xs:complexType>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attribute name="outlinePadding" type="floatDimensionType" default="0"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="BoundingRoundBox" substitutionGroup="BoundingShape">
+    <xs:complexType>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attribute name="cornerRadius" type="floatDimensionType" default="0" />
+      <xs:attribute name="outlinePadding" type="floatDimensionType" default="0"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="BoundingOval" substitutionGroup="BoundingShape">
+    <xs:complexType>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attribute name="outlinePadding" type="floatDimensionType" default="0"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="BoundingArc" substitutionGroup="BoundingShape">
+    <xs:complexType>
+      <xs:attribute name="centerX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="centerY" type="floatDimensionType" use="required"/>
+      <xs:attribute name="width" type="floatDimensionType" use="required"/>
+      <xs:attribute name="height" type="floatDimensionType" use="required"/>
+      <xs:attribute name="thickness" type="floatDimensionType" use="required"/>
+      <xs:attribute name="isRoundEdge" type="booleanType" default="FALSE"/>
+      <xs:attribute name="outlinePadding" type="floatDimensionType" default="0"/>
+
+      <xs:attributeGroup ref="angleAttributeGroupRequired"/>
+      <xs:attribute name="direction" default="CLOCKWISE">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="CLOCKWISE"/>
+            <xs:enumeration value="COUNTER_CLOCKWISE"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/complication/complicationElement.xsd
+++ b/third_party/wff/specification/documents/2/complication/complicationElement.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../group/part/partElementGroup.xsd"/>
+  <xs:include schemaLocation="../common/conditionElement.xsd"/>
+
+  <xs:simpleType name="complicationType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SHORT_TEXT"/>
+      <xs:enumeration value="LONG_TEXT"/>
+      <xs:enumeration value="MONOCHROMATIC_IMAGE"/>
+      <xs:enumeration value="SMALL_IMAGE"/>
+      <xs:enumeration value="PHOTO_IMAGE"/>
+      <xs:enumeration value="RANGED_VALUE"/>
+      <xs:enumeration value="GOAL_PROGRESS"/>
+      <xs:enumeration value="WEIGHTED_ELEMENTS"/>
+      <xs:enumeration value="EMPTY"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="Complication">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:group ref="PartElementGroup" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="Group" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="Condition" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:choice>
+      <xs:attribute name="type" type="complicationType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/complication/complicationSlotElement.xsd
+++ b/third_party/wff/specification/documents/2/complication/complicationSlotElement.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="defaultProviderPolicyElement.xsd"/>
+  <xs:include schemaLocation="boundingElement.xsd"/>
+  <xs:include schemaLocation="complicationElement.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd"/>
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../common/attributes/angleType.xsd"/>
+  <xs:include schemaLocation="../common/attributes/colorAttributes.xsd"/>
+  <xs:include schemaLocation="../common/booleanType.xsd"/>
+
+  <xs:simpleType name="complicationListType">
+    <xs:list itemType="complicationType"/>
+  </xs:simpleType>
+
+  <xs:element name="ComplicationSlot">
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="DefaultProviderPolicy" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="BoundingShape" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="Complication" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="ScreenReader" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+
+      <xs:attribute name="name" type="xs:string"/>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute name="angle" type="angleType"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="scaleX" type="xs:float"/>
+      <xs:attribute name="scaleY" type="xs:float"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+
+      <xs:attribute name="slotId" type="xs:string" use="required"/>
+      <xs:attribute name="supportedTypes" type="complicationListType" use="required"/>
+      <xs:attribute name="displayName" type="xs:string"/>
+      <xs:attribute name="isCustomizable" type="booleanType"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/complication/defaultProviderPolicyElement.xsd
+++ b/third_party/wff/specification/documents/2/complication/defaultProviderPolicyElement.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="complicationElement.xsd"/>
+
+  <xs:simpleType name="defaultProviderType">
+    <xs:annotation>
+      <xs:documentation>
+        System complication providers.
+        See
+        https://developer.android.com/reference/android/support/wearable/complications/SystemProviders
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="APP_SHORTCUT"/>
+      <xs:enumeration value="DATE"/>
+      <xs:enumeration value="DAY_OF_WEEK"/>
+      <xs:enumeration value="FAVORITE_CONTACT"/>
+      <xs:enumeration value="NEXT_EVENT"/>
+      <xs:enumeration value="STEP_COUNT"/>
+      <xs:enumeration value="SUNRISE_SUNSET"/>
+      <xs:enumeration value="TIME_AND_DATE"/>
+      <xs:enumeration value="UNREAD_NOTIFICATION_COUNT"/>
+      <xs:enumeration value="WATCH_BATTERY"/>
+      <xs:enumeration value="WORLD_CLOCK"/>
+      <xs:enumeration value="DAY_AND_DATE"/>
+      <xs:enumeration value="EMPTY"/>
+      <xs:enumeration value="HEART_RATE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="defaultProviderListType">
+    <xs:union memberTypes="defaultProviderType xs:string"/>
+  </xs:simpleType>
+
+  <xs:element name="DefaultProviderPolicy">
+    <xs:complexType>
+      <xs:attribute name="defaultSystemProvider" type="defaultProviderListType" use="required"/>
+      <xs:attribute name="defaultSystemProviderType" type="complicationType" use="required"/>
+      <xs:attribute name="primaryProvider" type="xs:string"/>
+      <xs:attribute name="primaryProviderType" type="complicationType" default="EMPTY"/>
+      <xs:attribute name="secondaryProvider" type="xs:string" />
+      <xs:attribute name="secondaryProviderType" type="complicationType" default="EMPTY"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/groupElement.xsd
+++ b/third_party/wff/specification/documents/2/group/groupElement.xsd
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="renderModeType.xsd"/>
+  <xs:include schemaLocation="part/partElementGroup.xsd"/>
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../common/launchElement.xsd"/>
+  <xs:include schemaLocation="../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../common/conditionElement.xsd"/>
+  <xs:include schemaLocation="../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../common/transform/gyroElements.xsd"/>
+  <xs:include schemaLocation="../userConfiguration/listConfigurationElement.xsd"/>
+  <xs:include schemaLocation="../userConfiguration/booleanConfigurationElement.xsd"/>
+  <xs:include schemaLocation="../common/variant/variantElements.xsd" />
+  <xs:include schemaLocation="../common/localizationElement.xsd"/>
+  <xs:include schemaLocation="../common/screenReaderElement.xsd"/>
+  <xs:include schemaLocation="../clock/analogClock.xsd"/>
+  <xs:include schemaLocation="../clock/digitalClock.xsd"/>
+
+  <xs:element name="Group">
+    <xs:annotation>
+      <xs:documentation>
+        The Group element contains other groups or parts as children.
+        This is an important node in the scene graph that lays out the components on the scene.
+        The group does not have the ability to draw on its own, but it affects the position, size,
+        angle or color of the child hierarchies.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Localization" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Gyro" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Launch" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Transform" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="Group" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartText" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartImage" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartAnimatedImage" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartDraw" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartVectorImage" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="ScreenReader" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Condition" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="ListConfiguration" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="BooleanConfiguration" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="AnalogClock" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="DigitalClock" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attribute name="id">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="name" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Name of this group.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attributeGroup ref="geometricAttributesRequired"/>
+      <xs:attributeGroup ref="pivot2D"/>
+      <xs:attribute name="angle" type="angleType"/>
+      <xs:attribute ref="alpha"/>
+      <xs:attribute name="scaleX" type='xs:float'/>
+      <xs:attribute name="scaleY" type='xs:float'/>
+      <xs:attribute name="renderMode" type="renderModeType" default="SOURCE"/>
+      <xs:attribute name="tintColor" type='colorAttributeType'/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/abstractPartType.xsd
+++ b/third_party/wff/specification/documents/2/group/part/abstractPartType.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../renderModeType.xsd"/>
+  <xs:include schemaLocation="../../common/localizationElement.xsd"/>
+  <xs:include schemaLocation="../../common/attributes/angleType.xsd"/>
+  <xs:include schemaLocation="../../common/attributes/colorAttributes.xsd"/>
+  <xs:include schemaLocation="../../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../../common/transform/gyroElements.xsd"/>
+  <xs:include schemaLocation="../../common/transform/pivotType.xsd"/>
+  <xs:include schemaLocation="../../common/variant/variantElements.xsd"/>
+  <xs:include schemaLocation="../../common/launchElement.xsd"/>
+  <xs:include schemaLocation="../../common/screenReaderElement.xsd"/>
+
+  <xs:complexType name="AbstractPartType" abstract="true" block="restriction">
+    <xs:annotation>
+      <xs:documentation>
+          The Part presents a visual element such image or text.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:all>
+      <xs:element ref="Localization" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="Transform" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="Gyro" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="Launch" minOccurs="0" maxOccurs="1"/>
+      <xs:element ref="ScreenReader" minOccurs="0" maxOccurs="1"/>
+    </xs:all>
+
+    <xs:attributeGroup ref="geometricAttributesRequired"/>
+    <xs:attributeGroup ref="pivot2D"/>
+    <xs:attribute name="angle" type="angleType"/>
+    <xs:attribute ref="alpha"/>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="scaleX" type='xs:float'/>
+    <xs:attribute name="scaleY" type='xs:float'/>
+    <xs:attribute name="renderMode" type="renderModeType" default="SOURCE"/>
+    <xs:attribute name="tintColor" type='colorAttributeType'/>
+  </xs:complexType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/animatedImage/animatedImageElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/animatedImage/animatedImageElement.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="partAnimatedImageElement.xsd"/>
+  <xs:element name="AnimatedImage" substitutionGroup="AnimatableImageElement">
+    <xs:complexType>
+      <xs:attribute name="resource" type="xs:string" use="required"/>
+      <xs:attribute name="format" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="IMAGE"/>
+            <xs:enumeration value="AGIF"/>
+            <xs:enumeration value="WEBP"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="thumbnail" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/animatedImage/animatedImagesElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/animatedImage/animatedImagesElement.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="partAnimatedImageElement.xsd"/>
+  <xs:include schemaLocation="animatedImageElement.xsd"/>
+  <xs:include schemaLocation="sequenceImageElement.xsd"/>
+  <xs:include schemaLocation="../../../common/eventTriggerType.xsd"/>
+
+  <xs:element name="AnimatedImages" substitutionGroup="AnimatableImageElement">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="AnimatedImage"/>
+        <xs:element ref="SequenceImages"/>
+      </xs:choice>
+
+      <xs:attribute name="change" type="eventTriggerListType" default="TAP"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/animatedImage/animationControllerElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/animatedImage/animationControllerElement.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../common/booleanType.xsd"/>
+  <xs:include schemaLocation="../../../common/eventTriggerType.xsd"/>
+  <xs:simpleType name="frameOptionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DO_NOTHING"/>
+      <xs:enumeration value="FIRST_FRAME"/>
+      <xs:enumeration value="THUMBNAIL"/>
+      <xs:enumeration value="HIDE"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="AnimationController">
+    <xs:complexType>
+      <xs:attribute name="play" type="eventTriggerListType" use="required"/>
+      <xs:attribute name="delayPlay" type="xs:float" default="0"/>
+      <xs:attribute name="delayRepeat" type="xs:float" default="0"/>
+      <xs:attribute name="repeat" type="booleanType" default="FALSE"/>
+      <xs:attribute name="loopCount" type="xs:integer" default="1"/>
+
+      <xs:attribute name="resumePlayBack" type="booleanType" default="FALSE"/>
+      <xs:attribute name="beforePlaying" type="frameOptionType" default="DO_NOTHING" />
+      <xs:attribute name="afterPlaying" type="frameOptionType" default="DO_NOTHING" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/animatedImage/partAnimatedImageElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/animatedImage/partAnimatedImageElement.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../abstractPartType.xsd"/>
+  <xs:include schemaLocation="../image/thumbnailElement.xsd"/>
+  <xs:include schemaLocation="animatedImageElement.xsd"/>
+  <xs:include schemaLocation="animatedImagesElement.xsd"/>
+  <xs:include schemaLocation="animationControllerElement.xsd"/>
+  <xs:include schemaLocation="sequenceImageElement.xsd"/>
+
+  <xs:element name="AnimatableImageElement" abstract="true"/>
+
+  <xs:element name="PartAnimatedImage">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="AbstractPartType">
+          <xs:all>
+            <xs:element ref="Thumbnail" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="AnimationController" minOccurs="1" maxOccurs="1"/>
+            <xs:element ref="AnimatableImageElement" minOccurs="1" maxOccurs="1"/>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/animatedImage/sequenceImageElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/animatedImage/sequenceImageElement.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="partAnimatedImageElement.xsd"/>
+  <xs:include schemaLocation="../image/imageElement.xsd"/>
+
+  <xs:simpleType name="frameRateRangeType">
+    <xs:annotation>
+      <xs:documentation>
+        frameRateRangeType allows input of frame rate value from 1 to 60
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[1-9]|[1-5][0-9]|60"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="SequenceImages" substitutionGroup="AnimatableImageElement">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Image" maxOccurs="unbounded"/>
+      </xs:choice>
+
+      <xs:attribute name="loopCount" type="xs:int" default="1"/>
+      <xs:attribute name="thumbnail" type="xs:string"/>
+      <xs:attribute name="frameRate" type="frameRateRangeType" default="15">
+        <xs:annotation>
+          <xs:documentation>
+            This allows users to set the speed at which frames included in the SequenceImages should
+            be played. For example, if the frameRate of SequenceImages with 30 images is set to 15,
+            it is animated to show 30 frames in 2 seconds. If the frameRate is set to 30, 30 frames
+            are played during 1 second.
+            This specifies the play speed of the content, and it doesn't work perfectly the same on
+            the actual watch face. For example, if a device constrains the fps of the watch face to
+            15, SequenceImages with frameRate set to 30 will usually be displayed by skipping 1 frame
+            to operate at a specified speed.
+
+            Since watch face format 2
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/gradient/linearGradientElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/gradient/linearGradientElement.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/primitiveListTypes.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+
+  <xs:element name="LinearGradient">
+    <xs:annotation>
+      <xs:documentation>
+        Set a gradient color consisting of a progressive transition between two or more colors along a straight line
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element maxOccurs="4" minOccurs="0" ref="Transform"/>
+      </xs:choice>
+
+      <xs:attribute name="startX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="startY" type="floatDimensionType" use="required"/>
+      <xs:attribute name="endX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="endY" type="floatDimensionType" use="required"/>
+      <xs:attribute name="colors" type="colorListType" use="required"/>
+      <xs:attribute name="positions" type="floatListType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/gradient/radialGradientElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/gradient/radialGradientElement.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="linearGradientElement.xsd"/>
+
+  <xs:element name="RadialGradient">
+    <xs:annotation>
+      <xs:documentation>
+        Set a gradient color consisting of a progressive transition between two or more colors that radiate from an origin
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element maxOccurs="3" minOccurs="0" ref="Transform"/>
+      </xs:choice>
+
+      <xs:attribute name="centerX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="centerY" type="floatDimensionType" use="required"/>
+      <xs:attribute name="radius" type="floatDimensionType" use="required"/>
+      <xs:attribute name="colors" type="colorListType" use="required"/>
+      <xs:attribute name="positions" type="floatListType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/gradient/sweepGradientElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/gradient/sweepGradientElement.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/angleType.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="linearGradientElement.xsd"/>
+
+  <xs:element name="SweepGradient">
+    <xs:annotation>
+      <xs:documentation>
+        Set a gradient color consisting of a progressive transition between two or more colors that
+        sweep an angle from startAngle to endAngle
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element maxOccurs="4" minOccurs="0" ref="Transform"/>
+      </xs:choice>
+
+      <xs:attribute name="centerX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="centerY" type="floatDimensionType" use="required"/>
+      <xs:attributeGroup ref="angleAttributeGroupRequired"/>
+      <xs:attribute name="colors" type="colorListType" use="required"/>
+      <xs:attribute name="positions" type="floatListType" use="required"/>
+
+      <xs:attribute name="direction" default="CLOCKWISE">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="CLOCKWISE"/>
+            <xs:enumeration value="COUNTER_CLOCKWISE"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/partDrawElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/partDrawElement.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../abstractPartType.xsd"/>
+  <xs:include schemaLocation="shape/lineElement.xsd"/>
+  <xs:include schemaLocation="shape/arcElement.xsd"/>
+  <xs:include schemaLocation="shape/rectangleElement.xsd"/>
+  <xs:include schemaLocation="shape/roundRectangleElement.xsd"/>
+  <xs:include schemaLocation="shape/ellipseElement.xsd"/>
+
+  <xs:element name="DrawElement" abstract="true"/>
+  <xs:element name="PartDraw">
+    <xs:annotation>
+      <xs:documentation>
+        PartDraw is element that draws primitive types of figure like line, rect, arc, circle and rounded rectangle.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="AbstractPartType">
+          <xs:all>
+            <xs:element ref="DrawElement" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/shape/arcElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/shape/arcElement.xsd
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../partDrawElement.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/angleType.xsd"/>
+  <xs:include schemaLocation="../style/strokeElement.xsd"/>
+  <xs:include schemaLocation="../style/weightedStrokeElement.xsd"/>
+
+  <xs:element name="Arc" substitutionGroup="DrawElement">
+    <xs:annotation>
+      <xs:documentation>
+        Draw arc line with given bound. Center point of arc is the center of the bounds.
+        Angle is given in degrees with 0 indicating 12 o'clock.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Stroke" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="WeightedStroke" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Transform" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attribute name="centerX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="centerY" type="floatDimensionType" use="required"/>
+      <xs:attribute name="width" type="floatDimensionType" use="required"/>
+      <xs:attribute name="height" type="floatDimensionType" use="required"/>
+      <xs:attributeGroup ref="angleAttributeGroupRequired"/>
+      <xs:attribute name="direction" default="CLOCKWISE">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="CLOCKWISE"/>
+            <xs:enumeration value="COUNTER_CLOCKWISE"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/shape/ellipseElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/shape/ellipseElement.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../partDrawElement.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../style/strokeElement.xsd"/>
+  <xs:include schemaLocation="../style/fillElement.xsd"/>
+
+  <xs:element name="Ellipse" substitutionGroup="DrawElement">
+    <xs:annotation>
+      <xs:documentation>
+        Draw (fill or stroke) ellipse shape with given bound.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Stroke" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Fill" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Transform" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attribute name="x" type="floatDimensionType" use="required"/>
+      <xs:attribute name="y" type="floatDimensionType" use="required"/>
+      <xs:attribute name="width" type="floatDimensionType" use="required"/>
+      <xs:attribute name="height" type="floatDimensionType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/shape/lineElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/shape/lineElement.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../partDrawElement.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../style/strokeElement.xsd"/>
+
+  <xs:element name="Line" substitutionGroup="DrawElement">
+    <xs:annotation>
+      <xs:documentation>
+        Draw line from start point to end point
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Stroke" minOccurs="1" maxOccurs="1" />
+        <xs:element ref="Transform" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attribute name="startX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="startY" type="floatDimensionType" use="required"/>
+      <xs:attribute name="endX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="endY" type="floatDimensionType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/shape/rectangleElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/shape/rectangleElement.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../partDrawElement.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../style/strokeElement.xsd"/>
+  <xs:include schemaLocation="../style/fillElement.xsd"/>
+
+  <xs:element name="Rectangle" substitutionGroup="DrawElement">
+    <xs:annotation>
+      <xs:documentation>
+        Draw (fill or stroke) rectangle shape with given bound.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Stroke" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Fill" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Transform" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attribute name="x" type="floatDimensionType" use="required"/>
+      <xs:attribute name="y" type="floatDimensionType" use="required"/>
+      <xs:attribute name="width" type="floatDimensionType" use="required"/>
+      <xs:attribute name="height" type="floatDimensionType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/shape/roundRectangleElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/shape/roundRectangleElement.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../partDrawElement.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../style/strokeElement.xsd"/>
+  <xs:include schemaLocation="../style/fillElement.xsd"/>
+
+  <xs:element name="RoundRectangle" substitutionGroup="DrawElement">
+    <xs:annotation>
+      <xs:documentation>
+        Draw (fill or stroke) rectangle shape that has rounded corners with given bounds.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Stroke" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Fill" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Transform" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+
+      <xs:attribute name="x" type="floatDimensionType" use="required"/>
+      <xs:attribute name="y" type="floatDimensionType" use="required"/>
+      <xs:attribute name="width" type="floatDimensionType" use="required"/>
+      <xs:attribute name="height" type="floatDimensionType" use="required"/>
+      <xs:attribute name="cornerRadiusX" type="floatDimensionType" use="required"/>
+      <xs:attribute name="cornerRadiusY" type="floatDimensionType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/style/fillElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/style/fillElement.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/colorAttributes.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd"/>
+  <xs:include schemaLocation="../gradient/linearGradientElement.xsd"/>
+  <xs:include schemaLocation="../gradient/radialGradientElement.xsd"/>
+  <xs:include schemaLocation="../gradient/sweepGradientElement.xsd"/>
+
+  <xs:element name="Fill">
+    <xs:annotation>
+      <xs:documentation>
+        Element that has attributes for a fill style
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="LinearGradient"/>
+        <xs:element ref="RadialGradient"/>
+        <xs:element ref="SweepGradient"/>
+      </xs:choice>
+
+      <xs:attribute name="color" type="colorAttributeType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/style/strokeElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/style/strokeElement.xsd
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../../common/transform/transformElements.xsd" />
+  <xs:include schemaLocation="../../../../common/attributes/colorAttributes.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd" />
+  <xs:include schemaLocation="../gradient/linearGradientElement.xsd"/>
+  <xs:include schemaLocation="../gradient/radialGradientElement.xsd"/>
+  <xs:include schemaLocation="../gradient/sweepGradientElement.xsd"/>
+
+  <xs:element name="Stroke">
+    <xs:annotation>
+      <xs:documentation>
+        Element that has attributes for a stroke style
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="LinearGradient" />
+        <xs:element ref="RadialGradient" />
+        <xs:element ref="SweepGradient" />
+        <xs:element ref="Transform" />
+      </xs:choice>
+
+      <xs:attribute name="color" type="colorAttributeType" use="required" />
+      <xs:attribute name="thickness" type="floatDimensionType" use="required" />
+      <xs:attribute name="dashIntervals" type="xs:string"/>
+      <xs:attribute name="dashPhase" type="xs:float"/>
+      <xs:attribute name="cap" default="BUTT">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="BUTT" />
+            <xs:enumeration value="ROUND" />
+            <xs:enumeration value="SQUARE" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/draw/style/weightedStrokeElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/draw/style/weightedStrokeElement.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:include schemaLocation="../../../../common/transform/transformElements.xsd" />
+    <xs:include schemaLocation="../../../../common/attributes/colorAttributes.xsd"/>
+    <xs:include schemaLocation="../../../../common/attributes/dimensionType.xsd" />
+
+    <xs:element name="WeightedStroke">
+        <xs:annotation>
+            <xs:documentation>
+                Stroke style with weight, each element can have different colors.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="Transform" />
+            </xs:choice>
+
+            <xs:attribute name="colors" type="colorListType" use="required" >
+                <xs:annotation>
+                    <xs:documentation>
+                        Series of color in hexadecimal like "#FF0000 #00FF00 #0000FF".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="weights" type="floatListType" default="" >
+                <xs:annotation>
+                    <xs:documentation>
+                        Series of weight in float like "3.0 4.0 5.0". Each value represents a
+                        portion of the stroke range.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="discreteGap" type="_nonNegativeFloat" default="0.0" >
+                <xs:annotation>
+                    <xs:documentation>
+                        This indicates the gap between elements. It is useful when the strokes
+                        split by weight are clearly divided, especially when there is a round cap.
+                        This is because each cap of the divided stroke overlaps each other as they
+                        are placed outside the stroke. To prevent overlapping caps, this value can
+                        be set to the value greater than or equal to the thickness of the stroke.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="interpolate" type="xs:string" default="false" >
+                <xs:annotation>
+                    <xs:documentation>
+                        If it is true, the stroke is drawn as a gradient color. Each segment takes
+                        two colors for gradation: from and to. It means that the number of colors should
+                        be one more than the number of weights. For example, two weights requires
+                        three colors to show a color gradient across all segments of the stroke.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="thickness" type="floatDimensionType" use="required" >
+                <xs:annotation>
+                    <xs:documentation>
+                        Width of stroke. Center of thickness is given arc geometry.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+
+            <xs:attribute name="cap" default="BUTT">
+                <xs:annotation>
+                    <xs:documentation>
+                        The Cap specifies the treatment for the beginning and ending of stroked lines and paths.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="BUTT" />
+                        <xs:enumeration value="ROUND" />
+                        <xs:enumeration value="SQUARE" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="_nonNegativeFloat">
+        <xs:restriction base="xs:float">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/image/imageElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/image/imageElement.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="partImageElement.xsd"/>
+  <xs:element name="Image" substitutionGroup="ImageElement">
+    <xs:annotation>
+      <xs:documentation>
+        An element for an image.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="resource" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Drawable id of image resource
+            or
+            Source of image. e.g., Some complications could have a source of image such as ICON,
+            SMALL_IMAGE or LARGE_IMAGE.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/image/imageFilter/hsbFilterElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/image/imageFilter/hsbFilterElement.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:include schemaLocation="hsbFilterElement.xsd" />
+	<xs:include schemaLocation="../../../../common/attributes/angleType.xsd" />
+	<xs:include schemaLocation="../../../../common/attributes/normalizedType.xsd" />
+
+	<xs:element name="HsbFilter">
+		<xs:annotation>
+			<xs:documentation>
+				A filter that adjusts pixels by hue, saturate or brightness
+			</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:attribute name="hueRotate" default="0" type="angleType" />
+			<xs:attribute name="saturate" default="1" type="normalizedType" />
+			<xs:attribute name="brightness" default="1" type="normalizedType" />
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/image/imageFilter/imageFiltersElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/image/imageFilter/imageFiltersElement.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:include schemaLocation="../partImageElement.xsd"/>
+	<xs:include schemaLocation="hsbFilterElement.xsd" />
+	<xs:element name="ImageFilters">
+		<xs:annotation>
+			<xs:documentation>
+				ImageFilters is a container for filters that affect the pixels in the bitmap.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:choice>
+				<xs:element ref="HsbFilter" />
+			</xs:choice>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/image/imagesElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/image/imagesElement.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="imageElement.xsd"/>
+  <xs:include schemaLocation="../../../common/eventTriggerType.xsd"/>
+
+  <xs:element name="Images" substitutionGroup="ImageElement">
+    <xs:annotation>
+      <xs:documentation>
+        Images is a container that has a series of image resources.
+        Only one image is shown at a time, and is changed using by tap.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Image"/>
+      </xs:choice>
+      <xs:attribute name="change" type="eventTriggerListType" default="TAP"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/image/partImageElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/image/partImageElement.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../abstractPartType.xsd" />
+  <xs:include schemaLocation="imageElement.xsd" />
+  <xs:include schemaLocation="imagesElement.xsd" />
+  <xs:include schemaLocation="imageFilter/imageFiltersElement.xsd" />
+
+  <xs:element name="ImageElement" abstract="true"/>
+
+  <xs:element name="PartImage">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="AbstractPartType">
+          <xs:all>
+            <xs:element ref="ImageFilters" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="ImageElement" minOccurs="1" maxOccurs="1"/>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="PartVectorImage">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="AbstractPartType">
+          <xs:all>
+            <xs:element ref="ImageFilters" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="ImageElement" minOccurs="1" maxOccurs="1"/>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/image/thumbnailElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/image/thumbnailElement.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Thumbnail">
+    <xs:complexType>
+      <xs:attribute name="resource" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/partElementGroup.xsd
+++ b/third_party/wff/specification/documents/2/group/part/partElementGroup.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="text/partTextElement.xsd"/>
+  <xs:include schemaLocation="image/partImageElement.xsd"/>
+  <xs:include schemaLocation="draw/partDrawElement.xsd"/>
+  <xs:include schemaLocation="animatedImage/partAnimatedImageElement.xsd"/>
+
+  <xs:group name="PartElementGroup">
+    <xs:choice>
+      <xs:element ref="PartText"/>
+      <xs:element ref="PartImage"/>
+      <xs:element ref="PartAnimatedImage"/>
+      <xs:element ref="PartDraw"/>
+      <xs:element ref="PartVectorImage"/>
+    </xs:choice>
+  </xs:group>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/bitmapFontElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/bitmapFontElement.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="textComponentGroup.xsd"/>
+
+  <xs:element name="BitmapFont">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies Bitmap font for text.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="TextFormatterGroup"/>
+      </xs:choice>
+      <xs:attribute name="family" type="xs:string" use="required"/>
+      <xs:attribute name="size" type="xs:float" use="required"/>
+      <xs:attribute name="color" type="colorAttributeType" default="#FFFFFF"/>
+      <xs:attribute name="letterSpacing" type="xs:float">
+        <xs:annotation>
+          <xs:documentation>
+            Letter-Spacing is space between letters. The default value is 0.
+            The value is in 'EM' units. Typical values for slight expansion will be around 0.05.
+            Negative values tighten text.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/decoration/abstractDecorationType.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/decoration/abstractDecorationType.xsd
@@ -1,0 +1,29 @@
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../formatter/formatterGroup.xsd"/>
+  <xs:include schemaLocation="underlineElement.xsd"/>
+  <xs:include schemaLocation="strikethroughElement.xsd"/>
+
+  <xs:complexType name="abstractDecorationType" mixed="true">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="TextFormatterGroup"/>
+      <xs:element ref="Underline"/>
+      <xs:element ref="StrikeThrough"/>
+    </xs:choice>
+  </xs:complexType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/decoration/decorationGroup.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/decoration/decorationGroup.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="shadowElement.xsd"/>
+  <xs:include schemaLocation="outlineElement.xsd"/>
+  <xs:include schemaLocation="outGlowElement.xsd"/>
+  <xs:include schemaLocation="underlineElement.xsd"/>
+  <xs:include schemaLocation="strikethroughElement.xsd"/>
+
+  <xs:group name="TextDecorationGroup">
+    <xs:choice>
+      <xs:element ref="Shadow"/>
+      <xs:element ref="Outline"/>
+      <xs:element ref="OutGlow"/>
+      <xs:element ref="Underline"/>
+      <xs:element ref="StrikeThrough"/>
+    </xs:choice>
+  </xs:group>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/decoration/outGlowElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/decoration/outGlowElement.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="abstractDecorationType.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/colorAttributes.xsd"/>
+
+  <xs:element name="OutGlow">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="abstractDecorationType">
+          <xs:attribute name="radius" type="xs:float"/>
+          <xs:attribute name="color" type="colorAttributeType" use="required"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/decoration/outlineElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/decoration/outlineElement.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="decorationGroup.xsd"/>
+
+  <xs:element name="Outline">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="abstractDecorationType">
+          <xs:attribute name="width" type="xs:float"/>
+          <xs:attribute name="color" type="colorAttributeType" use="required"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/decoration/shadowElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/decoration/shadowElement.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="decorationGroup.xsd"/>
+
+  <xs:element name="Shadow">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="abstractDecorationType">
+          <xs:attribute name="color" type="colorAttributeType" use="required"/>
+          <xs:attribute name="offsetX" type="xs:float"/>
+          <xs:attribute name="offsetY" type="xs:float"/>
+          <xs:attribute name="radius" type="xs:float"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/decoration/strikethroughElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/decoration/strikethroughElement.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="decorationGroup.xsd"/>
+
+  <xs:element name="StrikeThrough">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="abstractDecorationType"/>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/decoration/underlineElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/decoration/underlineElement.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="decorationGroup.xsd"/>
+
+  <xs:element name="Underline">
+    <xs:complexType mixed="true">
+      <xs:complexContent>
+        <xs:extension base="abstractDecorationType"/>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/fontElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/fontElement.xsd
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="textComponentGroup.xsd"/>
+
+  <xs:element name="Font">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies Font for text.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="TextComponentGroup"/>
+      </xs:choice>
+      <xs:attribute name="family" type="xs:string" use="required"/>
+      <xs:attribute name="size" type="xs:float" use="required"/>
+      <xs:attribute name="color" type="colorAttributeType" default="#FFFFFF"/>
+      <xs:attribute name="letterSpacing" type="xs:float">
+        <xs:annotation>
+          <xs:documentation>
+            Letter-Spacing is space between letters. The default value is 0.
+            The value is in 'EM' units. Typical values for slight expansion will be around 0.05.
+            Negative values tighten text.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="slant" default="NORMAL">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="NORMAL"/>
+            <xs:enumeration value="ITALIC"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="width" default="NORMAL">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="ULTRA_CONDENSED"/>
+            <xs:enumeration value="EXTRA_CONDENSED"/>
+            <xs:enumeration value="CONDENSED"/>
+            <xs:enumeration value="SEMI_CONDENSED"/>
+            <xs:enumeration value="NORMAL"/>
+            <xs:enumeration value="SEMI_EXPANDED"/>
+            <xs:enumeration value="EXPANDED"/>
+            <xs:enumeration value="EXTRA_EXPANDED"/>
+            <xs:enumeration value="ULTRA_EXPANDED"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="weight" default="NORMAL">
+        <xs:simpleType>
+          <!--https://developer.android.com/reference/android/graphics/Typeface#create(android.graphics.Typeface,%20int,%20boolean)-->
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="THIN"/>
+            <xs:enumeration value="ULTRA_LIGHT"/>
+            <xs:enumeration value="EXTRA_LIGHT"/>
+            <xs:enumeration value="LIGHT"/>
+            <xs:enumeration value="NORMAL"/>
+            <xs:enumeration value="MEDIUM"/>
+            <xs:enumeration value="SEMI_BOLD"/>
+            <xs:enumeration value="ULTRA_BOLD"/>
+            <xs:enumeration value="EXTRA_BOLD"/>
+            <xs:enumeration value="BLACK"/>
+            <xs:enumeration value="EXTRA_BLACK"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/formatter/formatterGroup.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/formatter/formatterGroup.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="inlineImageElement.xsd"/>
+  <xs:include schemaLocation="templateElement.xsd"/>
+  <xs:include schemaLocation="upperElement.xsd"/>
+  <xs:include schemaLocation="lowerElement.xsd"/>
+
+  <xs:group name="TextFormatterGroup">
+    <xs:choice>
+      <xs:element ref="InlineImage"/>
+      <xs:element ref="Template"/>
+      <xs:element ref="Upper"/>
+      <xs:element ref="Lower"/>
+    </xs:choice>
+  </xs:group>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/formatter/inlineImageElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/formatter/inlineImageElement.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../../common/attributes/geometricAttributes.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/colorAttributes.xsd"/>
+
+  <xs:element name="InlineImage">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation>
+          Element for an inline image which appears within text.
+          This image will be handled as text, not as an image element.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:attribute name="resource" type="xs:string" use="required"/>
+      <xs:attribute name="source" type="xs:string"/>
+      <xs:attribute name="color" type="colorAttributeType" default="#FFFFFFFF"/>
+      <xs:attribute name="overlapLeft" type="xs:float"/>
+      <xs:attribute name="overlapRight" type="xs:float"/>
+      <xs:attributeGroup ref="sizeAttributesRequired"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/formatter/lowerElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/formatter/lowerElement.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="formatterGroup.xsd"/>
+
+  <xs:element name="Lower">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Template"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/formatter/templateElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/formatter/templateElement.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../../../../common/booleanType.xsd"/>
+  <xs:include schemaLocation="../../../../common/attributes/arithmeticExpressionType.xsd"/>
+
+  <xs:element name="Parameter">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation>
+          Element specifying an argument for a Template.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:attribute name="expression" type="arithmeticExpressionType" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="Template">
+    <xs:complexType mixed="true">
+      <xs:annotation>
+        <xs:documentation>
+          Element for converting a specified format string and arguments to a formatted string.
+          This can be used similarly to printf() in C or String.format() in Java.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Parameter" maxOccurs="unbounded"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/formatter/upperElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/formatter/upperElement.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="formatterGroup.xsd"/>
+
+  <xs:element name="Upper">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Template"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/partTextElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/partTextElement.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../abstractPartType.xsd"/>
+  <xs:include schemaLocation="textElement.xsd"/>
+  <xs:include schemaLocation="textCircularElement.xsd"/>
+
+  <xs:element name="TextElement" abstract="true"/>
+
+  <xs:element name="PartText">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="AbstractPartType">
+          <xs:all>
+            <xs:element ref="TextElement" minOccurs="1" maxOccurs="1"/>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/textCircularElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/textCircularElement.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="partTextElement.xsd"/>
+  <xs:include schemaLocation="../../../common/attributes/angleType.xsd"/>
+  <xs:include schemaLocation="../../../common/circularDirectionType.xsd"/>
+  <xs:include schemaLocation="../../../common/transform/transformElements.xsd"/>
+  <xs:include schemaLocation="../../../common/attributes/alignmentAttribute.xsd"/>
+  <xs:include schemaLocation="fontElement.xsd"/>
+  <xs:include schemaLocation="bitmapFontElement.xsd"/>
+
+  <xs:element name="TextCircular" substitutionGroup="TextElement">
+    <xs:annotation>
+      <xs:documentation>
+        Specifies Circular Text configuration
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Transform"/>
+        <xs:element ref="Font"/>
+        <xs:element ref="BitmapFont"/>
+      </xs:choice>
+
+      <xs:attributeGroup ref="angleAttributeGroupRequired"/>
+      <xs:attribute name="centerX" type="xs:float" use="required"/>
+      <xs:attribute name="centerY" type="xs:float" use="required"/>
+      <xs:attribute name="direction" type="circularDirectionType"/>
+      <xs:attribute name="width" type="xs:float" use="required"/>
+      <xs:attribute name="height" type="xs:float" use="required"/>
+      <xs:attribute ref="align"/>
+      <xs:attribute name="ellipsis" type="booleanType" default="FALSE"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/textComponentGroup.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/textComponentGroup.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="decoration/decorationGroup.xsd"/>
+  <xs:include schemaLocation="formatter/formatterGroup.xsd"/>
+
+  <xs:group name="TextComponentGroup">
+    <xs:choice>
+      <xs:group ref="TextDecorationGroup"/>
+      <xs:group ref="TextFormatterGroup"/>
+    </xs:choice>
+  </xs:group>
+
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/part/text/textElement.xsd
+++ b/third_party/wff/specification/documents/2/group/part/text/textElement.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="partTextElement.xsd"/>
+  <xs:include schemaLocation="../../../common/attributes/alignmentAttribute.xsd"/>
+  <xs:include schemaLocation="fontElement.xsd"/>
+  <xs:include schemaLocation="bitmapFontElement.xsd"/>
+
+  <xs:element name="Text" substitutionGroup="TextElement">
+    <xs:annotation>
+      <xs:documentation>
+        Specifies Plain Text configuration for any text
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Font"/>
+        <xs:element ref="BitmapFont"/>
+      </xs:choice>
+
+      <xs:attribute ref="align"/>
+      <xs:attribute name="ellipsis" type="booleanType" default="FALSE"/>
+      <xs:attribute name="maxLines" type="xs:integer"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/group/renderModeType.xsd
+++ b/third_party/wff/specification/documents/2/group/renderModeType.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="renderModeType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SOURCE"/>
+      <xs:enumeration value="MASK"/>
+      <xs:enumeration value="ALL"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/metadataElement.xsd
+++ b/third_party/wff/specification/documents/2/metadataElement.xsd
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- preserved keys for meta data -->
+  <xs:simpleType name="_predefinedMetadataKeys">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PREVIEW_TIME">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies time for preview with format HH:MM:SS. e.g., 10:08:30
+            If this is not specified or is not an appropriate value, the system value is used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="CLOCK_TYPE">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies type of Clock.
+            The value must be either DIGITAL or ANALOG.
+            Even if your watch face contains both, you must specify a main type.
+            If this is not specified or is not an appropriate value, ANALOG is used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="STEP_GOAL">
+        <xs:annotation>
+          <xs:documentation>
+            Set the daily goal of steps. Must be a positive integer.
+            If this is not specified or is not an appropriate value, the system value is used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="_predefinedMetadataValues">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DIGITAL"/>
+      <xs:enumeration value="ANALOG"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="Metadata">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation>
+          Any pair of key-value can be added by user.
+        </xs:documentation>
+      </xs:annotation>
+
+      <!-- any key -->
+      <xs:attribute name="key" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Any unique key
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:union memberTypes="_predefinedMetadataKeys xs:string"/>
+        </xs:simpleType>
+      </xs:attribute>
+
+      <!-- any value -->
+      <xs:attribute name="value" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Any value
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:union memberTypes="_predefinedMetadataValues xs:string"/>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/sceneElement.xsd
+++ b/third_party/wff/specification/documents/2/sceneElement.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="group/groupElement.xsd"/>
+  <xs:include schemaLocation="userConfiguration/listConfigurationElement.xsd"/>
+  <xs:include schemaLocation="userConfiguration/booleanConfigurationElement.xsd"/>
+  <xs:include schemaLocation="complication/complicationSlotElement.xsd"/>
+  <xs:include schemaLocation="clock/analogClock.xsd"/>
+  <xs:include schemaLocation="clock/digitalClock.xsd"/>
+
+  <xs:element name="Scene">
+    <xs:annotation>
+      <xs:documentation>
+        Scene is a container of Visual tags. A watch face MUST include at least one Scene.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Group" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartText" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartImage" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartAnimatedImage" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="PartDraw" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="Condition" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="ListConfiguration" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="BooleanConfiguration" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="Variant" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="ComplicationSlot" minOccurs="0" maxOccurs="8"/>
+        <xs:element ref="AnalogClock" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="DigitalClock" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:all>
+      <xs:attribute name="backgroundColor" type="colorAttributeType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            The color of the scene's background.
+            Default value is #ff000000 (Black).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/abstractConfigurationType.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/abstractConfigurationType.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+
+  <xs:complexType name="AbstractConfigurationType">
+    <xs:attribute name="id" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Identifier of the configuration, this must be an unique value.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="displayName" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Title of the configuration. This text will be shown in the configuration activity. It is
+          recommended to use string resource id for localization.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="icon" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Icon of the configuration, this drawable will be shown in the configuration activity
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="screenReaderText" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Description text to be read by screen reader for accessibility. It is recommended to use
+          string resource id for localization.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="defaultValue" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Default configuration. Used if the user has not changed the value.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/booleanConfigurationElement.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/booleanConfigurationElement.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../group/part/partElementGroup.xsd"/>
+  <xs:include schemaLocation="../group/groupElement.xsd"/>
+  <xs:include schemaLocation="../common/booleanType.xsd"/>
+  <xs:include schemaLocation="../clock/digitalClock.xsd"/>
+
+  <xs:element name="BooleanConfiguration">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="BooleanOption">
+          <xs:complexType>
+            <xs:choice>
+              <xs:group ref="PartElementGroup"/>
+              <xs:element ref="Group"/>
+              <xs:element ref="Condition"/>
+              <xs:element ref="AnalogClock"/>
+              <xs:element ref="DigitalClock"/>
+            </xs:choice>
+            <xs:attribute name="id" type="booleanType" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/colorConfigurationElement.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/colorConfigurationElement.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../group/part/partElementGroup.xsd"/>
+  <xs:include schemaLocation="../group/groupElement.xsd"/>
+
+  <xs:element name="ColorConfiguration">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="ColorOption">
+          <xs:complexType>
+            <xs:choice>
+              <xs:group ref="PartElementGroup"/>
+              <xs:element ref="Group"/>
+            </xs:choice>
+            <xs:attribute name="id" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/flavorConfigurationType.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/flavorConfigurationType.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../common/attributes/geometricAttributes.xsd"/>
+
+  <xs:complexType name="FlavorConfigurationType">
+    <xs:attribute name="id" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Identifier of the configuration, this must be an unique value.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="displayName" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Title of the configuration. This text will be shown in the configuration activity. It is
+          recommended to use string resource id for localization.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="icon" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Icon of the configuration, this drawable will be shown in the configuration activity
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="screenReaderText" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Description text to be read by screen reader for accessibility. It is recommended to use
+          string resource id for localization.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/flavorElement.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/flavorElement.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="flavorConfigurationType.xsd"/>
+  <xs:include schemaLocation="../complication/defaultProviderPolicyElement.xsd"/>
+
+  <xs:element name="Flavor">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation>
+          The Flavor is a collection that can provide users with a combination of styles and
+          complications recommended by the developer.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="FlavorConfigurationType">
+          <xs:choice minOccurs="1" maxOccurs="100">
+            <xs:element name="Configuration">
+              <xs:complexType>
+                <xs:attribute name="id" type="xs:string" use="required">
+                  <xs:annotation>
+                    <xs:documentation>
+                      Identifier of the configuration. It must be the ID that is present in a
+                      configuration within UserConfiguration tag.
+                    </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="optionId" type="xs:string" use="required">
+                  <xs:annotation>
+                    <xs:documentation>
+                      Identifier of the option. It must be one of the options present in the
+                      configuration specified as id.
+                    </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="screenReaderText" type="xs:string">
+                  <xs:annotation>
+                    <xs:documentation>
+                      Description text to be read by screen reader for accessibility. It is
+                      recommended to use string resource id for localization.
+                    </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="ComplicationSlot">
+              <xs:complexType>
+                <xs:all>
+                  <xs:element ref="DefaultProviderPolicy" minOccurs="0" maxOccurs="1"/>
+                </xs:all>
+                <xs:attribute name="slotId" type="xs:string" use="required">
+                  <xs:annotation>
+                    <xs:documentation>
+                      Identifier of the complication slot. It must be one of the ComplicationSlots
+                      present in the Scene tag.
+                    </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
+              </xs:complexType>
+            </xs:element>
+          </xs:choice>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/flavorsElement.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/flavorsElement.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="FlavorsConfigurationType">
+    <xs:attribute name="defaultValue" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Default flavor configuration. Used if the user has not changed the value.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/listConfigurationElement.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/listConfigurationElement.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../group/part/partElementGroup.xsd"/>
+  <xs:include schemaLocation="../group/groupElement.xsd"/>
+  <xs:include schemaLocation="../clock/digitalClock.xsd"/>
+
+  <xs:element name="ListConfiguration">
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="ListOption">
+          <xs:complexType>
+            <xs:choice>
+              <xs:group ref="PartElementGroup"/>
+              <xs:element ref="Group"/>
+              <xs:element ref="Condition"/>
+              <xs:element ref="AnalogClock"/>
+              <xs:element ref="DigitalClock"/>
+            </xs:choice>
+            <xs:attribute name="id" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/userConfiguration/userConfigurationsElement.xsd
+++ b/third_party/wff/specification/documents/2/userConfiguration/userConfigurationsElement.xsd
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="abstractConfigurationType.xsd"/>
+  <xs:include schemaLocation="flavorsElement.xsd"/>
+  <xs:include schemaLocation="flavorElement.xsd"/>
+  <xs:include schemaLocation="../common/attributes/colorAttributes.xsd"/>
+  <xs:include schemaLocation="../common/attributes/primitiveListTypes.xsd"/>
+
+  <xs:element name="UserConfigurations">
+    <xs:annotation>
+      <xs:documentation>
+        UserConfigurations is a set of Configuration to support various appearance options.
+        These can be used for Colors, Type of Hands, Background, Complication etc.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="1" maxOccurs="20">
+        <xs:element name="ListConfiguration">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="AbstractConfigurationType">
+                <xs:choice minOccurs="1" maxOccurs="100" >
+                  <xs:element name="ListOption">
+                    <xs:complexType>
+                      <xs:attribute name="id" type="xs:string" use="required">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Identifier of the option, it should be an unique value.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="displayName" type="xs:string">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Name of the option.This text will be shown in the configuration activity.
+                            It is recommended to use string resource id for localization.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="screenReaderText" type="xs:string">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Description text to be read by screen reader for accessibility. It is
+                            recommended to use string resource id for localization.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="icon" type="xs:string">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Icon of the option, this drawable will be shown in the configuration
+                            activity.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:choice>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="BooleanConfiguration">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="AbstractConfigurationType"/>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ColorConfiguration">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="AbstractConfigurationType">
+                <xs:choice minOccurs="1" maxOccurs="100">
+                  <xs:element name="ColorOption">
+                    <xs:complexType>
+                      <xs:attribute name="id" type="xs:string" use="required">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Identifier of the option, it should be an unique value.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="displayName" type="xs:string">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Name of the option.This text will be shown in the configuration activity.
+                            It is recommended to use string resource id for localization.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="screenReaderText" type="xs:string">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Description text to be read by screen reader for accessibility. It is
+                            recommended to use string resource id for localization.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="icon" type="xs:string">
+                        <xs:annotation>
+                          <xs:documentation>
+                            Icon of the option, this drawable will be shown in the configuration
+                            activity.
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                      <xs:attribute name="colors" type="userStyleColorOptionType">
+                        <xs:annotation>
+                          <xs:documentation>
+                            List of color values
+                          </xs:documentation>
+                        </xs:annotation>
+                      </xs:attribute>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:choice>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Flavors">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="FlavorsConfigurationType">
+                <xs:annotation>
+                  <xs:documentation>
+                    Default configuration. Used if the user has not changed the value.
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:choice minOccurs="1" maxOccurs="20">
+                  <xs:element ref="Flavor" />
+                </xs:choice>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/documents/2/watchface.xsd
+++ b/third_party/wff/specification/documents/2/watchface.xsd
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Samsung Electronics Co., Ltd All Rights Reserved
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="metadataElement.xsd"/>
+  <xs:include schemaLocation="bitmapFontsElement.xsd"/>
+  <xs:include schemaLocation="sceneElement.xsd"/>
+  <xs:include schemaLocation="userConfiguration/userConfigurationsElement.xsd"/>
+
+  <xs:element name="WatchFace">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">
+        WatchFace is a root element of watchface.xml. It contains scheme version of the xml
+        specification and the information of the virtual screen used when the sub-elements are
+        created.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element ref="Metadata" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="UserConfigurations" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="BitmapFonts" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="Scene" minOccurs="1"/>
+      </xs:all>
+      <xs:attribute name="width" type="xs:positiveInteger" use="required">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Size of the visual screen in which watch face components are drawn. It is not related to
+            the display resolution of the real device, and all figures related to geometry(position
+            and dimension) among the attributes of the child elements indicate the relative position
+            and size in the virtual screen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="height" type="xs:positiveInteger" use="required">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Size of the visual screen in which watch face components are drawn. It is not related to
+            the display resolution of the real device, and all figures related to geometry(position
+            and dimension) among the attributes of the child elements indicate the relative position
+            and size in the virtual screen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="clipShape">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            Creators can require a shape that clips the result. This can be useful, for example, when
+            creators want to produce a circular result on a rectangular device. In some cases, there
+            may be objects that span outside the desired shape.
+            RECTANGLE shape with cornerRadiusX and cornerRadiusY attributes makes round-rectangle.
+            Default value is CIRCLE.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="CIRCLE"/>
+            <xs:enumeration value="RECTANGLE"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="cornerRadiusX" type="xs:float">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            The x-radius of the rounded corners on the rectangle.
+            It is available when the shape type is RECTANGLE.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="cornerRadiusY" type="xs:float">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+            The y-radius of the rounded corners on the rectangle.
+            It is available when the shape type is RECTANGLE.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+
+    <!-- Value validations -->
+    <!-- Metadata Value Validation -->
+    <xs:unique name="Validation.Unique.Metadata.key">
+      <xs:selector xpath="Metadata"/>
+      <xs:field xpath="@key"/>
+    </xs:unique>
+
+    <!-- BitmapFont Value Validation -->
+    <xs:unique name="Validation.Unique.WatchFace.BitmapFonts.BitmapFont.name">
+      <xs:selector xpath="BitmapFonts/*"/>
+      <xs:field xpath="@name"/>
+    </xs:unique>
+
+    <!-- Complication Value Validation -->
+    <xs:unique name="Validation.Unique.WatchFace.Scene.ComplicationSlot.slotId">
+      <xs:selector xpath="Scene/*"/>
+      <xs:field xpath="@slotId"/>
+    </xs:unique>
+
+    <!-- Groups Value Validation -->
+    <xs:unique name="Validation.Unique.WatchFace.Groups.type">
+      <xs:selector xpath="Groups"/>
+      <xs:field xpath="@type"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>

--- a/third_party/wff/specification/validator/build.gradle
+++ b/third_party/wff/specification/validator/build.gradle
@@ -34,7 +34,7 @@ jar {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 
-    setArchivesBaseName('dwf-format-1-validator-1.0')
+    setArchivesBaseName('dwf-format-2-validator-1.0')
     from ('build/libs') {
         include 'docs.zip'
     }

--- a/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
+++ b/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class DWFValidationApplication {
     private final static String APPLICATION_VERSION = "1.0";
-    private final static String MAX_SUPPORTED_FORMAT_VERSION = "1";
+    private final static String MAX_SUPPORTED_FORMAT_VERSION = "2";
     private WatchFaceXmlValidator validator;
 
     public static void main(String[] args) {


### PR DESCRIPTION
The Watch Face Format v2 will be available on Wear 5 devices released in the future.
The new spec contains new functionality as well as bug fixes over the older version.

Please refer to https://developer.android.com/training/wearables/wff/features for documentation which will be available shortly.

Note that Wear 4 devices will use the v1 specification unless they are upgraded to Wear 5 by the OEMs.
