### PR TITLE
Enhance the output of the xsd-validator tool

### DIFF
--- a/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
+++ b/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
@@ -96,11 +96,11 @@ public class DWFValidationApplication {
 
         if (validator.isSupportedVersion(targetFormatVersion)) {
             if (validator.validate(watchFaceXmlFilePath, targetFormatVersion)) {
-                Log.i("PASSED : " + watchFaceXmlFilePath +
+                Log.i("✅ "+" PASSED : " + watchFaceXmlFilePath +
                         " is valid against watch face format version #" + targetFormatVersion);
                 return true;
             } else {
-                Log.i("FAILED : " + watchFaceXmlFilePath +
+                Log.i("❌ "+" FAILED : " + watchFaceXmlFilePath +
                         " is NOT valid against watch face format version #" + targetFormatVersion);
                 return false;
             }


### PR DESCRIPTION
Added ✅ PASSED / ❌ FAILED to the validator tool output