### PR TITLE
Create a new workflow for the current release

### DIFF
--- a/.github/workflows/gradle-publish-base.yml
+++ b/.github/workflows/gradle-publish-base.yml
@@ -5,11 +5,16 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Release artifacts
-
 on:
-  push:
-    branches: [ "main" ]
+  workflow_call:
+    inputs:
+      release_git_sha:
+        type: string
+        description: The git sha of the commit from where the current release will be built from.
+        required: true
+      release_name:
+        type: string
+        required: true
 
 jobs:
   build_memory_footprint:
@@ -19,6 +24,8 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v3
+      with:
+        ref: {{ inputs.release_git_sha }}
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
@@ -48,7 +55,7 @@ jobs:
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
+        automatic_release_tag: "${{ inputs.release_name }}"
         prerelease: true
         title: "Memory Footprint Build"
         files: |

--- a/.github/workflows/gradle-publish-current.yml
+++ b/.github/workflows/gradle-publish-current.yml
@@ -1,0 +1,27 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+# The "current" release is built manually from a given git sha and it puts the artifacts
+# that are meant to be used currently on a permalink.
+
+name: Release current artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_git_sha:
+        type: string
+        description: The git sha of the commit from where the current release will be built from.
+        required: true
+
+jobs:
+  call-publish-base:
+    uses: ./.github/workflows/gradle-publish-base.yml
+    with:
+      release_git_sha: '${{ inputs.release_git_sha }}'
+      release_name: 'current'
+

--- a/.github/workflows/gradle-publish-latest.yml
+++ b/.github/workflows/gradle-publish-latest.yml
@@ -1,0 +1,20 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Release latest artifacts
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  call-publish-base:
+    uses: ./.github/workflows/gradle-publish-base.yml
+    with:
+      release_git_sha: ''
+      release_name: 'current'
+

--- a/.github/workflows/gradle-publish-latest.yml
+++ b/.github/workflows/gradle-publish-latest.yml
@@ -16,5 +16,5 @@ jobs:
     uses: ./.github/workflows/gradle-publish-base.yml
     with:
       release_git_sha: ''
-      release_name: 'current'
+      release_name: 'latest'
 

--- a/.github/workflows/gradle-publish-release.yml
+++ b/.github/workflows/gradle-publish-release.yml
@@ -5,10 +5,10 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-# The "current" release is built manually from a given git sha and it puts the artifacts
+# The "release" release is built manually from a given git sha and it puts the artifacts
 # that are meant to be used currently on a permalink.
 
-name: Release current artifacts
+name: Create the release artifacts
 
 on:
   workflow_dispatch:
@@ -23,5 +23,5 @@ jobs:
     uses: ./.github/workflows/gradle-publish-base.yml
     with:
       release_git_sha: '${{ inputs.release_git_sha }}'
-      release_name: 'current'
+      release_name: 'release'
 


### PR DESCRIPTION
The current release is meant to contain the artifacts that should be used in the validation pipeline at the current moment. It differs from "latest", which is built automatically and might contain changes that we do not want to be used for now.

To create a new current release, the new workflow must be triggered manually with the git sha of the commit from where we want to build the artifacts.

The artifacts will be available on the following permalink:
```
https://github.com/{owner}/{repo}/releases/download/{release-name}/{artifact-name}
```