### PR TITLE
Avoid stack overflow in AmbientMemoryFootprintCalculator

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ActiveMemoryFootprintCalculator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ActiveMemoryFootprintCalculator.java
@@ -1,5 +1,6 @@
 package com.google.wear.watchface.dfx.memory;
 
+import static com.google.wear.watchface.dfx.memory.DrawableResourceDetails.findInMap;
 import static com.google.wear.watchface.dfx.memory.WatchFaceDocuments.findSceneNode;
 
 import org.w3c.dom.Document;
@@ -30,11 +31,11 @@ public class ActiveMemoryFootprintCalculator {
                 new WatchFaceResourceCollector(document, resourceMemoryMap, evaluationSettings);
         return new DynamicNodePerConfigurationFootprintCalculator(
                         document,
-                        resourceMemoryMap,
                         evaluationSettings,
                         activeConfigValue,
                         resourceCollector,
-                        drawableNodeConfigTable)
+                        drawableNodeConfigTable,
+                        (res) -> findInMap(resourceMemoryMap, res).getTotalFootprintBytes())
                 .calculateMaxFootprintBytes();
     }
 }

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/UserConfigValue.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/UserConfigValue.java
@@ -16,6 +16,8 @@
 
 package com.google.wear.watchface.dfx.memory;
 
+import static com.google.wear.watchface.dfx.memory.WatchFaceDocuments.getNodeAttribute;
+
 import org.w3c.dom.Node;
 
 import java.util.Arrays;
@@ -38,6 +40,13 @@ import java.util.Optional;
  * <p>The UserConfigValues are: - for dateDisplayed: TRUE, FALSE, - for icon-id-option: 0, and 1.
  */
 class UserConfigValue {
+
+    public static UserConfigValue fromNode(Node node) {
+        return new UserConfigValue(
+                getNodeAttribute(node, "id")
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("Node does not contain an id")));
+    }
 
     /**
      * The UserConfiguration children node names that are treated as configuration values. We ignore


### PR DESCRIPTION
On some watch faces, there can be too many permutations of style configurations to compute, leading to a stack overflow or to a very long time when evaluating the memory footprint in Ambient.

With this change, instead of generating all the possible configurations of user style configurations, we only generate combinations that are necessary, for resources that cannot be evaluated independently.