### PR TITLE
Remove residual logs

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceLoader.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceLoader.java
@@ -167,7 +167,6 @@ public class AndroidResourceLoader {
 
                     @Override
                     public AndroidResource next() {
-                        System.out.println(zipEntry);
                         byte[] entryData;
                         try {
                             entryData = readAllBytes(baseSplitZipStream);


### PR DESCRIPTION
Remove a log that was left from a previous change and which adds to much spam to the output. This is important especially for the `--report` evaluation mode, where the tool should only print a JSON that can be consumed by other tools. Add a test that checks if the `--report` evaluation mode prints something that can be parsed as JSON to make sure no future residual logs break this behaviour.