### PR TITLE
Add test coverage for mutually exclusive images in ambient

### DIFF
--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculatorTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculatorTest.java
@@ -417,6 +417,28 @@ public class AmbientMemoryFootprintCalculatorTest {
     }
 
     @Test
+    public void understandsMutuallyExclusiveResources() throws Exception {
+        int digitalClock1Size = 16;
+        int digitalClock2Size = 2;
+        int digitalClock3Size = 8;
+        int digitalClock4Size = 32;
+        Map<String, DrawableResourceDetails> map =
+                ImmutableMap.<String, DrawableResourceDetails>builder()
+                        .put("digital-clock-16", resDetails("digital-clock-16", digitalClock1Size))
+                        .put("digital-clock-2", resDetails("digital-clock-2", digitalClock2Size))
+                        .put("digital-clock-8", resDetails("digital-clock-8", digitalClock3Size))
+                        .put("digital-clock-32", resDetails("digital-clock-32", digitalClock4Size))
+                        .build();
+        Document document = readDocument("MutuallyExclusiveBySameListId");
+
+        long result =
+                new AmbientMemoryFootprintCalculator(document, map, TEST_SETTINGS_V1_LIMITATIONS)
+                        .computeAmbientMemoryFootprint(TEST_WIDTH, TEST_HEIGHT);
+
+        assertThat(result).isEqualTo(digitalClock2Size + digitalClock4Size);
+    }
+
+    @Test
     public void resourceDeduplication() throws Exception {
         Map<String, DrawableResourceDetails> map =
                 ImmutableMap.<String, DrawableResourceDetails>builder()

--- a/play-validations/memory-footprint/src/test/resources/layer-split/MutuallyExclusiveBySameListId.xml
+++ b/play-validations/memory-footprint/src/test/resources/layer-split/MutuallyExclusiveBySameListId.xml
@@ -1,0 +1,41 @@
+<!-- Tests that mutually exclusive assets are not counted. Here, the same list-->
+<!-- configuration id is used in two different nodes. A naive calculator would-->
+<!-- find the maximum footprint to be the sum of digital-clock-16 and-->
+<!-- digital-clock-32 (48 bytes). However, these two are mutually exclusive because-->
+<!-- they are rendered under different options for the same l1 key. Instead, the-->
+<!-- true maximum footprint is computed when l1 takes the value l1-2, and it is-->
+<!-- digital-clock-2 + digital-clock-32 = 34-->
+<WatchFace width="450" height="450">
+    <UserConfigurations>
+        <ListConfiguration id="l1" displayName="list1" defaultValue="l1-1">
+            <ListOption id="l1-1" />
+            <ListOption id="l1-2" />
+        </ListConfiguration>
+    </UserConfigurations>
+    <Scene>
+        <ListConfiguration id="l1">
+            <ListOption id="l1-1">
+                <DigitalClock>
+                    <Image resource="digital-clock-16" />
+                </DigitalClock>
+            </ListOption>
+            <ListOption id="l1-2">
+                <DigitalClock>
+                    <Image resource="digital-clock-2" />
+                </DigitalClock>
+            </ListOption>
+        </ListConfiguration>
+        <ListConfiguration id="l1">
+            <ListOption id="l1-1">
+                <DigitalClock>
+                    <Image resource="digital-clock-8" />
+                </DigitalClock>
+            </ListOption>
+            <ListOption id="l1-2">
+                <DigitalClock>
+                    <Image resource="digital-clock-32" />
+                </DigitalClock>
+            </ListOption>
+        </ListConfiguration>
+    </Scene>
+</WatchFace>


### PR DESCRIPTION
Adds a missing test for a bug that was fixed by the previous refactoring. However, this was not covered by automated tests, so this change adds the test coverage to ensure this problem will not be introduced in the future.