### PR TITLE
memory-footprint: support --help option

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/EvaluationSettings.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/EvaluationSettings.kt
@@ -160,7 +160,10 @@ class EvaluationSettings(
             options.createOption {
                 longOpt("version").desc("Show the script's version and quit.").hasArg(false)
             }
-
+        val helpOption =
+            options.createOption {
+                longOpt("help").desc("Display this help message.").hasArg(false)
+            }
         val estimateOptimizationOption =
             options.createOption {
                 longOpt("estimate-optimization").desc("Assume DWF optimizations.").hasArg(false)
@@ -215,12 +218,21 @@ class EvaluationSettings(
 
                 val parser = DefaultParser()
                 try {
-                    val line = parser.parse(options, arguments)
-                    line.hasOption(versionOption)
-                    if (line.hasOption(versionOption)) {
-                        printVersion()
-                        exitProcess(0)
+                    arguments.forEach { arg ->
+                        when (arg) {
+                            "--version" -> {
+                                printVersion()
+                                exitProcess(0)
+                            }
+                            "--help" -> {
+                                HelpFormatter().printHelp(cliInvokeCommand, options, true)
+                                exitProcess(0)
+                            }
+                            else -> {}
+                        }
                     }
+
+                    val line = parser.parse(options, arguments)
 
                     validateSchemaVersion(line.getOptionValue(schemaVersionOption))
                     val evaluationSettings =


### PR DESCRIPTION
Makes `--version` and `--help` work by manually parsing the arguments before launching into `parser.parse()`. (Calling `parser.parse()` with `--help` on the command-line throws an exception, because various arguments such as "watch-face" are marked required.

`--version` still doesn't work properly due to #49.