### PR TITLE
Log footprints of images in active

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ActiveMemoryFootprintCalculator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ActiveMemoryFootprintCalculator.java
@@ -23,7 +23,10 @@ public class ActiveMemoryFootprintCalculator {
         this.evaluationSettings = evaluationSettings;
     }
 
-    long computeAmbientMemoryFootprint() {
+    long computeActiveMemoryFootprint() {
+        if (evaluationSettings.isVerbose()) {
+            System.out.println(">> Starting active evaluation");
+        }
         DrawableNodeConfigTable drawableNodeConfigTable =
                 DrawableNodeConfigTable.create(findSceneNode(document), activeConfigValue);
         WatchFaceResourceCollector resourceCollector =
@@ -34,7 +37,23 @@ public class ActiveMemoryFootprintCalculator {
                         activeConfigValue,
                         resourceCollector,
                         drawableNodeConfigTable,
-                        (res) -> findInMap(resourceMemoryMap, res).getTotalFootprintBytes())
+                        this::evaluateResource)
                 .calculateMaxFootprintBytes();
+    }
+
+    private long evaluateResource(String resource) {
+        DrawableResourceDetails details = findInMap(resourceMemoryMap, resource);
+        long imageBytes = details.getTotalFootprintBytes();
+        if (evaluationSettings.isVerbose()) {
+            System.out.printf(
+                    "Counting resource %s; %s bytes, %s mb, %s x %s %s%n",
+                    resource,
+                    details.getBiggestFrameFootprintBytes(),
+                    ((double) imageBytes) / 1024 / 1024,
+                    details.getWidth(),
+                    details.getHeight(),
+                    details.canUseRGB565() ? "RGB565" : "ARGB8888");
+        }
+        return imageBytes;
     }
 }

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AmbientMemoryFootprintCalculator.java
@@ -126,6 +126,9 @@ class AmbientMemoryFootprintCalculator {
      * and the memory needed for all the full screen layers.
      */
     long computeAmbientMemoryFootprint(long screenWidth, long screenHeight) {
+        if (evaluationSettings.isVerbose()) {
+            System.out.println(">> Starting ambient evaluation");
+        }
         Visitor visitor = new Visitor(/* prevNodeIsDrawnDynamically= */ true, /* numClocks= */ 0);
         visitor.visitNodes(findSceneNode(document));
 

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceLayoutEvaluator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceLayoutEvaluator.java
@@ -53,7 +53,7 @@ class WatchFaceLayoutEvaluator {
 
         long maxInActive =
                 new ActiveMemoryFootprintCalculator(document, resourceMemoryMap, settings)
-                        .computeAmbientMemoryFootprint();
+                        .computeActiveMemoryFootprint();
         long maxInAmbient =
                 new AmbientMemoryFootprintCalculator(document, resourceMemoryMap, settings)
                         .computeAmbientMemoryFootprint(450, 450);


### PR DESCRIPTION
In verbose mode, print the footprint of images counted for active. Add logs to indicate when the ambient and the active calculations start.

closes #10 