### PR TITLE
Adds support for version qualifiers

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResource.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResource.kt
@@ -16,6 +16,8 @@
 
 package com.google.wear.watchface.dfx.memory
 
+import com.google.common.annotations.VisibleForTesting
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.regex.Pattern
@@ -27,12 +29,13 @@ class AndroidResource(
     // Resource name, for example "watchface" for res/raw/watchface.xml.
     val resourceName: String,
     // File extension of the resource, for example "xml" for res/raw/watchface.xml
-    private val extension: String,
+    @VisibleForTesting val extension: String,
     // Path in the package. This is the obfuscated path to the actual data, where obfuscation has
     // been used, for example "res/raw/watchface.xml" may point to something like "res/li.xml".
     val filePath: Path,
     // The resource data itself.
-    val data: ByteArray
+    val data: ByteArray,
+    val versionQualifier: Int = NO_VERSION_QUALIFIER,
 ) {
     // TODO: This should be improved to parse res/xml/watch_face_info.xml where present, so as not
     // to assume all XML files in the res/raw directory are watch face XML files.
@@ -48,20 +51,34 @@ class AndroidResource(
 
     companion object {
         private val VALID_RESOURCE_PATH: Pattern =
-            Pattern.compile(".*res/([^-/]+).*/([^.]+)(\\.|)(.*|)$")
-        private const val VALID_RESOURCE_GROUPS: Int = 4
+            Pattern.compile(".*res/([^-/]+)(|.*-v(\\d+)|-.*)/([^.]+)[.]?(.*|)$")
+        private const val VALID_RESOURCE_GROUPS: Int = 5
+        const val NO_VERSION_QUALIFIER: Int = -1
 
         @JvmStatic
         fun fromPath(filePath: Path, data: ByteArray): AndroidResource {
             val pathWithFwdSlashes = filePath.toString().replace('\\', '/')
-            val matcher = VALID_RESOURCE_PATH.matcher(pathWithFwdSlashes)
-            if (matcher.matches() && matcher.groupCount() == VALID_RESOURCE_GROUPS) {
-                val resType = matcher.group(1)
-                val resName = matcher.group(2)
-                val ext = matcher.group(4)
-                return AndroidResource(resType, resName, ext, filePath, data)
+            val m = VALID_RESOURCE_PATH.matcher(pathWithFwdSlashes)
+
+            // Extracts both scenarios without a version resource qualifier, e.g. /res/raw and those
+            // with a version resource qualifier, e.g. /res/raw-v34 or /res/raw-round-v34. The
+            // version qualifier is always last in the list of qualifiers.
+            if (m.matches() && m.groupCount() == VALID_RESOURCE_GROUPS) {
+                val resType = m.group(1)
+                var qualifierVersion = NO_VERSION_QUALIFIER
+                if (m.group(2) != null && m.group(2).isNotEmpty() &&
+                    m.group(3) != null && m.group(3).isNotEmpty()
+                ) {
+                    qualifierVersion = m.group(3).toInt()
+                }
+                val resName = m.group(4)
+                val ext = m.group(5)
+                return AndroidResource(resType, resName, ext, filePath, data, qualifierVersion)
             }
-            throw RuntimeException("Not a valid resource file: $pathWithFwdSlashes")
+            throw InvalidPathException(
+                filePath.toString(),
+                "Not a valid resource file"
+            )
         }
 
         @JvmStatic

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceLoader.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceLoader.kt
@@ -20,6 +20,8 @@ import com.google.common.io.Files
 import com.google.devrel.gmscore.tools.apk.arsc.BinaryResourceFile
 import com.google.devrel.gmscore.tools.apk.arsc.BinaryResourceValue
 import com.google.devrel.gmscore.tools.apk.arsc.ResourceTableChunk
+import com.google.devrel.gmscore.tools.apk.arsc.TypeChunk
+import com.google.wear.watchface.dfx.memory.AndroidResourceLoader.versionQualifier
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Path
@@ -127,16 +129,27 @@ object AndroidResourceLoader {
             .map { entry ->
                 val path = stringPool.getString(entry.value().data())
                 val data = apkFile.getInputStream(ZipEntry(path)).readBytes()
+
                 AndroidResource(
                     entry.parent().typeName,
                     entry.key(),
                     Files.getFileExtension(path),
                     Paths.get(path),
-                    data
+                    data,
+                    entry.versionQualifier
                 )
             }
     }
 
     @JvmStatic
     fun readAllBytes(steam: InputStream) = steam.readBytes()
+
+    // If the entry in the table has a version qualifier, use that, otherwise use the special value
+    // to indicate that no version qualifier is present.
+    private val TypeChunk.Entry.versionQualifier: Int
+        get() = if (parent().configuration.sdkVersion() > 0) {
+            parent().configuration.sdkVersion()
+        } else {
+            AndroidResource.NO_VERSION_QUALIFIER
+        }
 }

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceData.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceData.kt
@@ -27,13 +27,13 @@ import kotlin.streams.asSequence
 internal class WatchFaceData private constructor() {
 
     /** Mutable backing field for [watchFaceDocuments]. */
-    private val _watchFaceDocuments = mutableListOf<Document>()
+    private val _watchFaceDocuments = mutableListOf<WatchFaceDocument>()
 
     /**
      * The parsed watchface xml documents. A watch face can have multiple layout files for different
      * screen shapes and resolutions.
      */
-    val watchFaceDocuments: List<Document> = _watchFaceDocuments
+    val watchFaceDocuments: List<WatchFaceDocument> = _watchFaceDocuments
 
     /** Mutable backing field for [resourceDetailsMap]. */
     private val _resourceDetailsMap = mutableMapOf<String, DrawableResourceDetails>()
@@ -100,7 +100,8 @@ internal class WatchFaceData private constructor() {
                 if (resource.isWatchFaceXml()) {
                     val document = parseXmlResource(resource.data)
                     if (isWatchFaceDocument(document, evaluationSettings)) {
-                        watchFaceData._watchFaceDocuments.add(document)
+                        watchFaceData._watchFaceDocuments
+                            .add(WatchFaceDocument(document, resource.versionQualifier))
                         continue
                     }
                 }

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceDocument.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceDocument.kt
@@ -1,0 +1,22 @@
+package com.google.wear.watchface.dfx.memory
+
+import com.google.wear.watchface.dfx.memory.AndroidResource.Companion.NO_VERSION_QUALIFIER
+import org.w3c.dom.Document
+
+data class WatchFaceDocument(val document: Document, private val versionQualifier: Int) {
+    companion object {
+        // If no WFF version has been attached to this document, namely, it came from an unqualified
+        // directory, e.g. /res/raw, not /res/raw-v34 etc.
+        const val NO_WFF_VERSION: Int = -1
+
+        // WFFv1 corresponds to API level 33, v2 to 34, etc.
+        const val WFF_VERSION_OFFSET: Int = 32
+    }
+
+    val wffVersion: Int
+        get() = if (versionQualifier == NO_VERSION_QUALIFIER) {
+            NO_WFF_VERSION
+        } else {
+            versionQualifier - WFF_VERSION_OFFSET
+        }
+}

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AndroidResourceTest.kt
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AndroidResourceTest.kt
@@ -1,0 +1,79 @@
+package com.google.wear.watchface.dfx.memory
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.nio.file.InvalidPathException
+
+@RunWith(JUnit4::class)
+class AndroidResourceTest {
+    @Test
+    fun fromPath_validResourceNoQualifiers() {
+        val path = "res/raw/watchface.xml"
+        val resource = AndroidResource.fromPath(path, byteArrayOf())
+
+        assertThat(resource.resourceName).isEqualTo("watchface")
+        assertThat(resource.isWatchFaceXml()).isEqualTo(true)
+        assertThat(resource.isRaw()).isEqualTo(true)
+        assertThat(resource.extension).isEqualTo("xml")
+        assertThat(resource.versionQualifier).isEqualTo(AndroidResource.NO_VERSION_QUALIFIER);
+    }
+
+    @Test
+    fun fromPath_validResourceNoExtension() {
+        val path = "res/drawable/preview"
+        val resource = AndroidResource.fromPath(path, byteArrayOf())
+
+        assertThat(resource.resourceName).isEqualTo("preview")
+        assertThat(resource.isWatchFaceXml()).isEqualTo(false)
+        assertThat(resource.isDrawable()).isEqualTo(true)
+        assertThat(resource.extension).isEqualTo("")
+    }
+
+    @Test
+    fun fromPath_invalidResourcePath() {
+        assertThrows(InvalidPathException::class.java) {
+            val path = "resxyz/drawable/preview.png"
+            AndroidResource.fromPath(path, byteArrayOf())
+        }
+    }
+
+    @Test
+    fun fromPath_validWatchfaceWithVersionQualifier() {
+        val path = "res/raw-v34/watchface.xml"
+        val resource = AndroidResource.fromPath(path, byteArrayOf())
+
+        assertThat(resource.resourceName).isEqualTo("watchface")
+        assertThat(resource.isWatchFaceXml()).isEqualTo(true)
+        assertThat(resource.isRaw()).isEqualTo(true)
+        assertThat(resource.extension).isEqualTo("xml")
+        assertThat(resource.versionQualifier).isEqualTo(34)
+    }
+
+    @Test
+    fun fromPath_validResourceWithVersionQualifier() {
+        val path = "res/drawable-nodpi/image.png"
+        val resource = AndroidResource.fromPath(path, byteArrayOf())
+
+        assertThat(resource.resourceName).isEqualTo("image")
+        assertThat(resource.isWatchFaceXml()).isEqualTo(false)
+        assertThat(resource.isDrawable()).isEqualTo(true)
+        assertThat(resource.extension).isEqualTo("png")
+        assertThat(resource.versionQualifier).isEqualTo(AndroidResource.NO_VERSION_QUALIFIER);
+    }
+
+    @Test
+    fun fromPath_validResourceWithMultipleQualifier() {
+        val path = "res/raw-round-v34/watchface.xml"
+        val resource = AndroidResource.fromPath(path, byteArrayOf())
+
+        assertThat(resource.resourceName).isEqualTo("watchface")
+        assertThat(resource.isWatchFaceXml()).isEqualTo(true)
+        assertThat(resource.isRaw()).isEqualTo(true)
+        assertThat(resource.extension).isEqualTo("xml")
+        assertThat(resource.versionQualifier).isEqualTo(34)
+    }
+}

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/InputPackageTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/InputPackageTest.java
@@ -3,7 +3,6 @@ package com.google.wear.watchface.dfx.memory;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.Streams;
-import com.google.common.truth.Correspondence;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -34,32 +33,22 @@ public class InputPackageTest {
     @Parameterized.Parameter(1)
     public String testAabDirectory;
 
-    private static final Correspondence<AndroidResource, String> VERIFY_PACKAGE_NAME_ONLY =
-            Correspondence.transforming(
-                    packageFile -> packageFile.getFilePath().toString(),
-                    "has the same file path as");
-
     @Test
     public void open_handlesFolder() {
-        List<AndroidResource> packageFiles;
+        List<String> packageFileNames;
         AndroidManifest manifest;
         try (InputPackage inputPackage = InputPackage.open(testAabDirectory)) {
-            packageFiles =
+            packageFileNames =
                     Streams.stream(inputPackage.getWatchFaceFiles().iterator())
+                            .map(x -> x.getFilePath().toString())
                             // remove this file, which is automatically created on MacOS
-                            .filter(
-                                    x ->
-                                            !x.getFilePath()
-                                                    .getFileName()
-                                                    .toString()
-                                                    .equals(".DS_Store"))
+                            .filter(x -> !x.equals(".DS_Store"))
                             .collect(Collectors.toList());
 
             manifest = inputPackage.getManifest();
         }
 
-        assertThat(packageFiles)
-                .comparingElementsUsing(VERIFY_PACKAGE_NAME_ONLY)
+        assertThat(packageFileNames)
                 .containsExactly(
                         "base/res/drawable-nodpi/bg.png",
                         "base/res/drawable-nodpi/dial.png",
@@ -71,6 +60,7 @@ public class InputPackageTest {
                         "base/res/font/roboto_regular.ttf",
                         "base/res/font/open_sans_regular.ttf",
                         "base/res/raw/watchface.xml",
+                        "base/res/raw-v34/watchface.xml",
                         "base/res/values/strings.xml",
                         "base/res/xml/watch_face_info.xml",
                         "base/manifest/AndroidManifest.xml");

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluatorTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluatorTest.java
@@ -100,7 +100,7 @@ public class ResourceMemoryEvaluatorTest {
                                             /* expectedActiveFootprintBytes= */ 4712628
                                                     + SYSTEM_DEFAULT_FONT_SIZE,
                                             /* expectedAmbientFootprintBytes= */ 2687628,
-                                            /* expectedLayouts= */ 1))
+                                            /* expectedLayouts= */ 2))
                     .collect(Collectors.toList());
         }
 

--- a/play-validations/memory-footprint/test-samples/sample-wf/src/main/res/raw-v34/watchface.xml
+++ b/play-validations/memory-footprint/test-samples/sample-wf/src/main/res/raw-v34/watchface.xml
@@ -1,0 +1,63 @@
+<WatchFace width="450" height="450" clipShape="CIRCLE">
+    <UserConfigurations>
+        <ListConfiguration id="handShape" defaultValue="0" displayName="@string/hand">
+            <ListOption id="handShape1" displayName="@string/hand_option_1" />
+            <ListOption id="handShape2" displayName="@string/hand_option_2" />
+        </ListConfiguration>
+    </UserConfigurations>
+    <Scene backgroundColor="#ff000000">
+
+        <PartImage x="0" y="0" width="450" height="450" name="background" pivotX="0.5" pivotY="0.5">
+            <Image resource="bg" />
+        </PartImage>
+        <PartImage x="0" y="0" width="450" height="450" name="dial" pivotX="0.5" pivotY="0.5">
+            <Image resource="dial" />
+        </PartImage>
+
+        <PartText x="0" y="300" width="350" height="100" name="label">
+            <Text align="CENTER" ellipsis="FALSE">
+                <Font family="SYNC_TO_DEVICE" size="24" weight="NORMAL" slant="NORMAL" color="#ffffffff" letterSpacing="1">
+                    Sample Watch Face
+                </Font>
+            </Text>
+        </PartText>
+
+        <Group x="0" y="0" width="450" height="450" name="handGroup" angle="0" pivotX="0.5"
+            pivotY="0.5" alpha="255">
+            <ListConfiguration id="handShape">
+                <ListOption id="handShape1">
+                    <PartImage x="0" y="0" width="450" height="450" name="hourHand" angle="0"
+                               pivotX="0.5" pivotY="0.5">
+                        <Transform target="angle"
+                                   value="0 + (clamp([HOUR_0_23_MINUTE], 0, 24) + 0 - 0) * 30 * (-1)" />
+                        <Image resource="hand_1" />
+                    </PartImage>
+                </ListOption>
+                <ListOption id="handShape2">
+                    <PartImage x="0" y="0" width="450" height="450" name="hourHand" angle="0"
+                               pivotX="0.5" pivotY="0.5">
+                        <Transform target="angle"
+                                   value="0 + (clamp([HOUR_0_23_MINUTE], 0, 24) + 0 - 0) * 30 * (-1)" />
+                        <Image resource="hand_2" />
+                    </PartImage>
+                </ListOption>
+            </ListConfiguration>
+        </Group>
+        <PartImage x="0" y="0" width="450" height="450" name="dial" pivotX="0.5" pivotY="0.5">
+            <Image resource="shape_1" />
+        </PartImage>
+        <PartImage x="0" y="0" width="450" height="450" name="dial" pivotX="0.5" pivotY="0.5">
+            <Image resource="shape_2" />
+        </PartImage>
+        <DigitalClock alpha="255" width="190" height="174" x="120" y="100">
+            <TimeText align="CENTER" alpha="255" format="hh:mm" height="174" hourFormat="SYNC_TO_DEVICE" width="190" x="0" y="0">
+                <Font color="#ffffffff" family="roboto_regular" size="50" slant="NORMAL" weight="NORMAL" />
+            </TimeText>
+        </DigitalClock>
+        <DigitalClock alpha="255" width="190" height="174" x="120" y="180">
+            <TimeText align="CENTER" alpha="255" format="hh:mm" height="174" hourFormat="SYNC_TO_DEVICE" width="190" x="0" y="0">
+                <Font color="#ffffffff" family="open_sans_regular" size="50" slant="NORMAL" weight="NORMAL" />
+            </TimeText>
+        </DigitalClock>
+    </Scene>
+</WatchFace>


### PR DESCRIPTION
Ensures that WFF resources that use a API level [resource qualifier](https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources) are handled correctly for validation purposes.

For example `res/raw-v34/watchface.xml`