### PR TITLE
Simplify AndroidManifest parsing

### DIFF
--- a/play-validations/build.gradle
+++ b/play-validations/build.gradle
@@ -24,6 +24,7 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+//        classpath 'com.guardsquare:proguard-gradle:7.1.0'
     }
 }
 
@@ -35,6 +36,7 @@ allprojects { project ->
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 
     // Ignore third party code

--- a/play-validations/memory-footprint/build.gradle
+++ b/play-validations/memory-footprint/build.gradle
@@ -25,12 +25,10 @@ dependencies {
     implementation 'com.google.guava:guava:33.3.1-jre'
     implementation 'commons-cli:commons-cli:1.5.0'
     implementation 'com.android.tools.apkparser:binary-resources:31.7.3'
-    implementation 'com.android.tools.apkparser:apkanalyzer:31.7.3'
-    implementation("com.android.tools.build:bundletool:1.17.2")
+    implementation 'com.github.xgouchet:AXML:v1.0.1'
     implementation("com.android.tools.build:aapt2-proto:8.7.3-12006047")
-    implementation("com.google.protobuf:protobuf-java:3.25.5")
+    implementation("com.google.protobuf:protobuf-java:4.29.3")
     implementation project(':validator')
-
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.4.4'


### PR DESCRIPTION
Reduce the size of the binary by replacing and reduce the libraries used to parse the android manifest of an input package. For APKs, the library is replaced with a more lightweight one, while for AABs, the parsing is refactored to work on the Proto XML nodes directly, removing the need for adding the bundletool dependency.