### PR TITLE
Fix lint issues

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidManifest.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidManifest.kt
@@ -6,7 +6,6 @@ import fr.xgouchet.axml.CompressedXmlParser
 import org.w3c.dom.Document
 import java.io.ByteArrayInputStream
 import java.io.InputStream
-import java.nio.file.Files
 import java.nio.file.Path
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -15,8 +14,6 @@ import javax.xml.namespace.NamespaceContext
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.xpath.XPathConstants
 import javax.xml.xpath.XPathFactory
-import kotlin.io.path.ExperimentalPathApi
-import kotlin.io.path.walk
 
 private const val ANDROID_MANIFEST_FILE_NAME = "AndroidManifest.xml"
 private const val DWF_PROPERTY_NAME = "com.google.wear.watchface.format.version"
@@ -114,14 +111,12 @@ class AndroidManifest private constructor(
             return loadFromBinaryXml(inputStream)
         }
 
-        @OptIn(ExperimentalPathApi::class)
         @JvmStatic
         fun loadFromAabDirectory(aabPath: Path): AndroidManifest {
-            val childrenFiles = aabPath.walk()
-            val manifestPath = childrenFiles
-                .filter { p: Path -> p.endsWith(ANDROID_MANIFEST_FILE_NAME) }.first()
-            val inputStream = Files.newInputStream(manifestPath)
-            return loadFromPlainXml(inputStream.readAllBytes())
+            val childrenFiles = aabPath.toFile().walk()
+            val manifestFile = childrenFiles
+                .filter { p -> p.toPath().endsWith(ANDROID_MANIFEST_FILE_NAME) }.first()
+            return loadFromPlainXml(manifestFile.readBytes())
         }
 
         @JvmStatic

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/DynamicNodePerConfigurationFootprintCalculator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/DynamicNodePerConfigurationFootprintCalculator.java
@@ -40,6 +40,7 @@ import org.w3c.dom.Node;
  * watch face interactivity is restricted, only a sub-set of the dynamic nodes are calculated (the
  * clocks and complication slots).
  */
+@SuppressWarnings("KotlinInternal")
 class DynamicNodePerConfigurationFootprintCalculator {
     private final Document document;
     private final EvaluationSettings evaluationSettings;

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import org.w3c.dom.Document;
 
 /** Computes the asset memory footprint for a given watch face. */
+@SuppressWarnings("KotlinInternal")
 public class ResourceMemoryEvaluator {
 
     private static final int EXIT_STATUS_BAD_ARGUMENTS = 2;

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceResourceCollector.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/WatchFaceResourceCollector.java
@@ -38,6 +38,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+@SuppressWarnings("KotlinInternal")
 class WatchFaceResourceCollector {
     private final Map<String, Node> bitmapFontDefinitions;
     private final Map<String, DrawableResourceDetails> resourceMemoryMap;


### PR DESCRIPTION
Suppress the KotlinInternal warning. The use of internal declarations is intentional, and will be refactored to Kotlin eventually.

Remove an experimental Kotlin API usage and replace it with a stable one from Java.