### PR TITLE
Allow evaluating directories without a manifest

### DIFF
--- a/play-validations/memory-footprint/build.gradle
+++ b/play-validations/memory-footprint/build.gradle
@@ -110,6 +110,7 @@ test {
             "test-samples:sample-wf:bundleRelease",
             "test-samples:sample-wf:assembleRelease",
             "test-samples:sample-wf:unpackBundle",
+            "test-samples:sample-wf:resDirectory",
             "test-samples:sample-wf:zipApk"
     )
 }

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidManifest.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidManifest.kt
@@ -112,11 +112,11 @@ class AndroidManifest private constructor(
         }
 
         @JvmStatic
-        fun loadFromAabDirectory(aabPath: Path): AndroidManifest {
+        fun loadFromAabDirectory(aabPath: Path): AndroidManifest? {
             val childrenFiles = aabPath.toFile().walk()
             val manifestFile = childrenFiles
-                .filter { p -> p.toPath().endsWith(ANDROID_MANIFEST_FILE_NAME) }.first()
-            return loadFromPlainXml(manifestFile.readBytes())
+                .filter { p -> p.toPath().endsWith(ANDROID_MANIFEST_FILE_NAME) }.firstOrNull()
+            return manifestFile?.let { loadFromPlainXml(it.readBytes()) }
         }
 
         @JvmStatic

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/InputPackage.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/InputPackage.kt
@@ -34,7 +34,7 @@ interface InputPackage : AutoCloseable {
      */
     fun getWatchFaceFiles(): Sequence<AndroidResource>
 
-    fun getManifest(): AndroidManifest
+    fun getManifest(): AndroidManifest?
 
     /** Close the backing watch face package resource. */
     override fun close()

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
@@ -118,18 +118,30 @@ public class ResourceMemoryEvaluator {
                             inputPackage.getWatchFaceFiles(), evaluationSettings);
             if (!evaluationSettings.isHoneyfaceMode()) {
                 AndroidManifest manifest = inputPackage.getManifest();
-                String manifestWffVersion = String.valueOf(manifest.getWffVersion());
+                String manifestWffVersion =
+                        manifest == null ? null : String.valueOf(manifest.getWffVersion());
                 String cliWffVersion = evaluationSettings.getSchemaVersion();
-                if (cliWffVersion != null
-                        && !cliWffVersion.equals(manifestWffVersion)
-                        && !evaluationSettings.isReportMode()) {
-                    System.out.printf(
-                            "Warning: Specified WFF version (%s) "
-                                    + "does not match version in manifest (%s)%n",
-                            cliWffVersion, manifestWffVersion);
+
+                String wffVersion;
+                if (cliWffVersion == null && manifestWffVersion == null) {
+                    throw new TestFailedException(
+                            "No WFF version could be inferred. When running the memory footprint"
+                                    + " tool with a directory and without the --schema-version"
+                                    + " argument, the directory must contain an AndroidManifest.xml"
+                                    + " file");
+                } else {
+                    if (cliWffVersion != null
+                            && manifestWffVersion != null
+                            && !cliWffVersion.equals(manifestWffVersion)
+                            && !evaluationSettings.isReportMode()) {
+                        System.out.printf(
+                                "Warning: Specified WFF version (%s) "
+                                        + "does not match version in manifest (%s)%n",
+                                cliWffVersion, manifestWffVersion);
+                    }
+                    wffVersion = cliWffVersion != null ? cliWffVersion : manifestWffVersion;
                 }
-                validateFormat(
-                        watchFaceData, cliWffVersion != null ? cliWffVersion : manifestWffVersion);
+                validateFormat(watchFaceData, wffVersion);
             }
             return watchFaceData.getWatchFaceDocuments().stream()
                     .map(

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AndroidManifestTest.kt
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AndroidManifestTest.kt
@@ -53,11 +53,11 @@ class AndroidManifestTest {
 
         val manifest = AndroidManifest.loadFromAabDirectory(wffDirectory)
 
-        assertThat(manifest.wffVersion).isEqualTo(1)
+        assertThat(manifest?.wffVersion).isEqualTo(1)
         // The unbundled manifest does not specify min and target SDKs, which according to specs
         // should then default to: minSdk -> 1, targetSdk -> minSdk.
-        assertThat(manifest.minSdkVersion).isEqualTo(1)
-        assertThat(manifest.targetSdkVersion).isEqualTo(1)
+        assertThat(manifest?.minSdkVersion).isEqualTo(1)
+        assertThat(manifest?.targetSdkVersion).isEqualTo(1)
     }
 
     @Test

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluatorTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluatorTest.java
@@ -60,15 +60,19 @@ public class ResourceMemoryEvaluatorTest {
 
             final int expectedLayouts;
 
+            final String cliSchemaVersion;
+
             private TestParams(
                     String watchFace,
                     long expectedActiveFootprintBytes,
                     long expectedAmbientFootprintBytes,
-                    int expectedLayouts) {
+                    int expectedLayouts,
+                    String cliSchemaVersion) {
                 this.watchFace = watchFace;
                 this.expectedActiveFootprintBytes = expectedActiveFootprintBytes;
                 this.expectedAmbientFootprintBytes = expectedAmbientFootprintBytes;
                 this.expectedLayouts = expectedLayouts;
+                this.cliSchemaVersion = cliSchemaVersion;
             }
 
             @Override
@@ -86,6 +90,7 @@ public class ResourceMemoryEvaluatorTest {
 
             return Stream.of(
                             "unpackedBundle/release",
+                            "resDirectory",
                             "apk/release/sample-wf-release.apk",
                             "apk/debug/sample-wf-debug.apk",
                             "bundle/release/sample-wf-release.aab",
@@ -100,14 +105,22 @@ public class ResourceMemoryEvaluatorTest {
                                             /* expectedActiveFootprintBytes= */ 4712628
                                                     + SYSTEM_DEFAULT_FONT_SIZE,
                                             /* expectedAmbientFootprintBytes= */ 2687628,
-                                            /* expectedLayouts= */ 1))
+                                            /* expectedLayouts= */ 1,
+                                            /* cliSchemaVersion= */ artifactRelativePath.equals(
+                                                            "resDirectory")
+                                                    ? "1"
+                                                    : null))
                     .collect(Collectors.toList());
         }
 
         @Test
         public void validate_hasExpectedFootprint() {
             List<MemoryFootprint> multiShapesFootprint =
-                    evaluateMemoryFootprint(new EvaluationSettings(testParams.watchFace));
+                    evaluateMemoryFootprint(
+                            testParams.cliSchemaVersion == null
+                                    ? new EvaluationSettings(testParams.watchFace)
+                                    : new EvaluationSettings(
+                                            testParams.watchFace, testParams.cliSchemaVersion));
 
             assertEquals(testParams.expectedLayouts, multiShapesFootprint.size());
             assertEquals(

--- a/play-validations/memory-footprint/test-samples/sample-wf/build.gradle
+++ b/play-validations/memory-footprint/test-samples/sample-wf/build.gradle
@@ -52,6 +52,15 @@ afterEvaluate {
         }
     }
 
+    // create a directory containing only a res sub-directory, used for tests
+    tasks.register("resDirectory", Copy) {
+        into layout.buildDirectory.dir("outputs/resDirectory/release")
+
+        from(layout.projectDirectory.dir("src/main/res")) {
+            into("res")
+        }
+    }
+
     // create a zip that follows the structure used internally, for tests
     tasks.register('zipApk', Zip) {
         duplicatesStrategy DuplicatesStrategy.INCLUDE


### PR DESCRIPTION
In some circumstances, it is useful to evaluate only a res directory, without an AndroidManifest file. The schema-version can be passed from the CLI, so the manifest file is not a necessity for the memory footprint tool. Add a test to check that this works well.