### PR TITLE
Adds versioning to tool builds

### DIFF
--- a/.github/workflows/gradle-publish-base.yml
+++ b/.github/workflows/gradle-publish-base.yml
@@ -39,8 +39,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           build-root-directory: play-validations
-          arguments: memory-footprint:jar -Dmemory-footprint.git_hash=${{ env.git_hash }} -Dmemory-footprint.version=latest
-      - name: Build dwf-format-1-validator-1.0.jar
+          arguments: memory-footprint:jar -Dmemory-footprint.git_hash=${{ env.git_hash }} 
+      - name: Build wff-validator
         uses: gradle/actions/setup-gradle@v3
         with:
           build-root-directory: third_party/wff
@@ -48,7 +48,7 @@ jobs:
       - name: Copy LICENSE files
         run: |
           mv LICENSE.txt memory-footprint_LICENSE.txt
-          mv third_party/wff/LICENSE.txt dwf-format-2-validator-1.0_LICENSE.txt
+          mv third_party/wff/LICENSE.txt wff-validator_LICENSE.txt
       - name: Create XSD archive
         run: |
           cd third_party/wff/specification/documents/
@@ -62,7 +62,7 @@ jobs:
           title: "Memory Footprint Build"
           files: |
             memory-footprint_LICENSE.txt
-            dwf-format-2-validator-1.0_LICENSE.txt
+            wff-validator_LICENSE.txt
             **/memory-footprint.jar
-            **/dwf-format-2-validator-1.0.jar
+            **/wff-validator.jar
             **/wff-xsd.zip

--- a/play-validations/memory-footprint/build.gradle
+++ b/play-validations/memory-footprint/build.gradle
@@ -18,6 +18,8 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version "2.0.21"
 }
 
+def baseVersion = "1.0.0"
+
 dependencies {
     implementation 'com.twelvemonkeys.imageio:imageio-webp:3.9.4'
     implementation 'com.twelvemonkeys.imageio:imageio-core:3.9.4'
@@ -70,9 +72,7 @@ jar {
         if (System.getProperty("memory-footprint.git_hash")) {
             attributes "Git-Hash": System.getProperty("memory-footprint.git_hash")
         }
-        if (System.getProperty("memory-footprint.version")) {
-            attributes "Version": System.getProperty("memory-footprint.version")
-        }
+        attributes "Version": baseVersion
     }
 
     from {

--- a/third_party/wff/README.md
+++ b/third_party/wff/README.md
@@ -22,20 +22,20 @@ cd third_party/wff
 ./gradlew :specification:validator:build
 ```
 
-The resulting JAR file can then be found at: `specification/validator/build/libs/dwf-format-2-validator-1.0.jar`
+The resulting JAR file can then be found at: `specification/validator/build/libs/wff-validator.jar`
 
 ### Usage
 
 To check whether a watch face is valid, invoke the validator as follows:
 
 ```shell
-java -jar dwf-format-2-validator-1.0.jar <format-version> <any options> <your-watchface.xml> <more-watchface.xml>
+java -jar wff-validator.jar <format-version> <any options> <your-watchface.xml> <more-watchface.xml>
 ```
 
 For example:
 
 ```shell
-java -jar dwf-format-2-validator-1.0.jar 2 ~/MyWatchface/res/raw/watchface.xml
+java -jar wff-validator.jar 2 ~/MyWatchface/res/raw/watchface.xml
 ```
 
 [xsd-files]: specification/documents/1

--- a/third_party/wff/specification/validator/build.gradle
+++ b/third_party/wff/specification/validator/build.gradle
@@ -15,6 +15,9 @@
  */
 apply plugin: 'java-library'
 
+def baseVersion="1.0.0"
+def baseArchivesName="wff-validator"
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
@@ -34,13 +37,14 @@ jar {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 
-    base.archivesName = 'dwf-format-2-validator-1.0'
+    base.archivesName.set(baseArchivesName)
     from ('build/libs') {
         include 'docs.zip'
     }
 
     manifest {
         attributes 'Main-Class': 'com.samsung.watchface.DWFValidationApplication'
+        attributes 'Version': baseVersion
     }
 }
 

--- a/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
+++ b/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
@@ -19,12 +19,17 @@ package com.samsung.watchface;
 import com.samsung.watchface.utils.Log;
 import com.samsung.watchface.utils.OptionParser;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 public class DWFValidationApplication {
-    private final static String APPLICATION_VERSION = "1.0";
+    private final static String APPLICATION_NAME = "wff-validator";
     private final static String MAX_SUPPORTED_FORMAT_VERSION = "2";
     private WatchFaceXmlValidator validator;
 
@@ -64,7 +69,7 @@ public class DWFValidationApplication {
     }
 
     public DWFValidationApplication() {
-        Log.i("DWF Validation Application Version "+ APPLICATION_VERSION +
+        Log.i("WFF Validation Application Version "+ getVersion() +
                 ". Maximum Supported Format Version #" + MAX_SUPPORTED_FORMAT_VERSION);
     }
 
@@ -77,8 +82,7 @@ public class DWFValidationApplication {
 
     private static void printUsage() {
         System.out.println("Usage : " +
-                "java -jar dwf-format-" + MAX_SUPPORTED_FORMAT_VERSION +
-                "-validator-" + APPLICATION_VERSION + ".jar" +
+                "java -jar " + APPLICATION_NAME + ".jar " +
                 " <format-version> <any options> <your-watchface.xml> <more-watchface.xml> ...");
     }
 
@@ -108,5 +112,27 @@ public class DWFValidationApplication {
             Log.i("Not supported version : " + targetFormatVersion);
             return false;
         }
+    }
+
+    /**
+     * Get the version of the application from the MANIFEST.MF file.
+     *
+     * @return The version of the application
+     */
+    private static String getVersion() {
+        String className = DWFValidationApplication.class.getName().replace('.', '/') + ".class";
+        String classJar = DWFValidationApplication.class.getResource("/" + className).toString();
+        if (classJar.startsWith("jar:")) {
+            String manifestPath = classJar.substring(0, classJar.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
+            Manifest manifest = null;
+            try {
+                manifest = new Manifest(new URL(manifestPath).openStream());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            Attributes attr = manifest.getMainAttributes();
+            return attr.getValue("Version");
+        }
+        throw new RuntimeException("Version not found in manifest");
     }
 }

--- a/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
+++ b/third_party/wff/specification/validator/src/main/java/com/samsung/watchface/DWFValidationApplication.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -120,19 +121,16 @@ public class DWFValidationApplication {
      * @return The version of the application
      */
     private static String getVersion() {
-        String className = DWFValidationApplication.class.getName().replace('.', '/') + ".class";
-        String classJar = DWFValidationApplication.class.getResource("/" + className).toString();
-        if (classJar.startsWith("jar:")) {
-            String manifestPath = classJar.substring(0, classJar.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
-            Manifest manifest = null;
-            try {
-                manifest = new Manifest(new URL(manifestPath).openStream());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+        Enumeration<URL> resources = null;
+        try {
+            resources = DWFValidationApplication.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+            while (resources.hasMoreElements()) {
+                Manifest manifest = new Manifest(resources.nextElement().openStream());
+                return manifest.getMainAttributes().getValue("Version");
             }
-            Attributes attr = manifest.getMainAttributes();
-            return attr.getValue("Version");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        throw new RuntimeException("Version not found in manifest");
+        throw new RuntimeException("Version not found in MANIFEST.MF");
     }
 }


### PR DESCRIPTION
#### WHAT

Adds semantic version numbers to the WFF validator and Memory Footprint tools

#### WHY

* To assist the publishing process
* Additionally, for the WFF validator, the version was previously baked into the code and then into the resulting jar filename, which made it both hard to update and also made the output brittle.

#### HOW

* Adds a version property to each respective `build.gradle`
* Updates the `gradle-publish-base.yml` workflow

#### Checklist :clipboard:
- [X] Run spotless check
- [X] Run tests