### PR TITLE
Adds write content permission for publishing workflows

### DIFF
--- a/.github/workflows/gradle-publish-base.yml
+++ b/.github/workflows/gradle-publish-base.yml
@@ -16,6 +16,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   build_memory_footprint:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle-publish-latest.yml
+++ b/.github/workflows/gradle-publish-latest.yml
@@ -11,6 +11,9 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+
 jobs:
   call-publish-base:
     uses: ./.github/workflows/gradle-publish-base.yml

--- a/.github/workflows/gradle-publish-release.yml
+++ b/.github/workflows/gradle-publish-release.yml
@@ -18,6 +18,9 @@ on:
         description: The git sha of the commit from where the current release will be built from.
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   call-publish-base:
     uses: ./.github/workflows/gradle-publish-base.yml


### PR DESCRIPTION
Adds write permission for publishing workflows, owing to 403 errors in previous executions when trying to publish.

Testing on another branch with these permissions worked successfully.