### PR TITLE
Adds package publishing for watch face tools

### DIFF
--- a/.github/workflows/gradle-publish-base.yml
+++ b/.github/workflows/gradle-publish-base.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build_memory_footprint:
@@ -61,7 +62,7 @@ jobs:
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ inputs.release_name }}"
-          prerelease: true
+          prerelease: false
           title: "Memory Footprint Build"
           files: |
             memory-footprint_LICENSE.txt
@@ -69,3 +70,82 @@ jobs:
             **/memory-footprint.jar
             **/wff-validator.jar
             **/wff-xsd.zip
+
+  publish_packages:
+    runs-on: ubuntu-latest
+    needs: build_memory_footprint
+    env:
+      GH_TOKEN: ${{ github.token }}
+    strategy:
+      matrix:
+        jar_file: [wff-validator.jar, memory-footprint.jar]
+    steps:
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
+      - name: Download asset
+        run: |
+          gh release download --repo "$GITHUB_REPOSITORY" --pattern ${{ matrix.jar_file }} 
+      - name: Get JAR version
+        id: get_version
+        run: |
+          VERSION=$(unzip -p ${{ matrix.jar_file }} META-INF/MANIFEST.MF | grep "^Version: " | cut -d' ' -f2)
+          if [[ -z "$VERSION" ]]; then
+            echo "::error file=${{ matrix.jar_file }}::Could not determine version from JAR's Manifest file"
+            exit 1
+          fi
+          echo "::set-output name=version::$VERSION"
+      - name: Determine final version
+        id: final_version
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if ${{ inputs.release_name == 'latest' }}; then
+            VERSION="$VERSION-SNAPSHOT"
+          fi
+          echo "::set-output name=final_version::$VERSION"
+      - name: Determine artefact ID
+        id: artefact_id
+        run: |
+          FILE_NAME="${{ matrix.jar_file }}"
+          FILE_NAME_WITHOUT_EXTENSION="${FILE_NAME%.*}"
+          echo "::set-output name=artefact_id::$FILE_NAME_WITHOUT_EXTENSION"
+      - name: Check if Maven package already exists
+        id: check_exists
+        run: |
+          VERSION="${{ steps.final_version.outputs.final_version }}"
+          ARTEFACT_ID=${{ steps.artefact_id.outputs.artefact_id }}
+
+          METADATA_URL="https://maven.pkg.github.com/google/watchface/com.google.watchface/${ARTIFACT_ID}/${VERSION}/maven-metadata.xml"
+
+          if ${{ inputs.release_name == 'latest' }}; then
+            # SNAPSHOT version should always publish
+            echo "::set-output name=should_publish::true"
+          elif curl -s -f -o /dev/null -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "$METADATA_URL"; then
+            # Don't republish existing non-SNAPSHOT versions
+            echo "Maven package with version $VERSION already exists."
+          else
+            echo "Maven package with version $VERSION does not exist."
+            echo "::set-output name=should_publish::true"
+          fi
+      - name: create settings.xml
+        if: steps.check_exists.outputs.should_publish == 'true'
+        run: |
+          mkdir -p ~/.m2
+          echo "<settings><servers><server><id>github</id><configuration><httpHeaders><property><name>Authorization</name><value>Bearer ${{ secrets.GITHUB_TOKEN }}</value></property></httpHeaders></configuration></server></servers></settings>" > ~/.m2/settings.xml
+        shell: bash
+        env:
+          GITHUB_PATH: ~/.m2/
+      - name: Publish to GitHub Packages
+        if: steps.check_exists.outputs.should_publish == 'true'
+        run: |
+          mvn deploy:deploy-file \
+            -DgroupId=com.google.watchface \
+            -DartifactId=${{ steps.artefact_id.outputs.artefact_id }} \
+            -Dversion=${{ steps.final_version.outputs.final_version }} \
+            -Dpackaging=jar \
+            -Dfile=${{ matrix.jar_file }} \
+            -Durl=https://maven.pkg.github.com/google/watchface \
+            -DrepositoryId=github -s ~/.m2/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle-publish-latest.yml
+++ b/.github/workflows/gradle-publish-latest.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   call-publish-base:

--- a/.github/workflows/gradle-publish-release.yml
+++ b/.github/workflows/gradle-publish-release.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   call-publish-base:


### PR DESCRIPTION
Adds package publishing for `wff-validator` and `memory-footprint`.

*-SNAPSHOT packages are published with every new "latest"-tagged release, and regular packages for each "release"-tagged release, where the tool version has not been already published.

Improvements can be made to the enforcement or automation of version incrementing for these tools, as a follow up.

