### PR TITLE
Add api to find memory footprint that throws exceptions

### DIFF
--- a/play-validations/memory-footprint/build.gradle
+++ b/play-validations/memory-footprint/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version "2.0.21"
 }
 
-def baseVersion = "1.3.0"
+def baseVersion = "1.4.0"
 
 dependencies {
     implementation 'com.twelvemonkeys.imageio:imageio-webp:3.9.4'


### PR DESCRIPTION
Add api to find memory footprint that throws exceptions in case a schema validation is not possible.