### PR TITLE
Improve error messaging on missing configurations

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceConfigTable.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceConfigTable.kt
@@ -142,7 +142,14 @@ internal class ResourceConfigTable(
         // in this object's resourceNameToKeys, replace each reference to a user config key with the
         // top level user config definition, which contains all allowed values
         val resourceNameToTopLevelKeys = resourceNameToKeys.entries().asSequence()
-            .map { it.key!! to userConfigKeys[it.value.keyId]!! }
+            .map {
+                val configurationId = it.value.keyId!!
+                if (userConfigKeys.containsKey(configurationId)) {
+                    it.key!! to userConfigKeys[configurationId]!!
+                } else {
+                    throw TestFailedException("Configuration $configurationId is not declared in UserConfigurations.")
+                }
+            }
             .toMultimap()
 
         return ResourceConfigTable(resourceNameToTopLevelKeys)

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluatorTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluatorTest.java
@@ -1119,6 +1119,24 @@ public class ResourceMemoryEvaluatorTest {
         }
 
         @Test
+        public void evaluateWatchFaceForLayout_failsOnMissingConfigurationDeclaration()
+                throws Exception {
+            try (InputStream is =
+                    getClass().getResourceAsStream("/MissingConfigurationDeclaration.xml")) {
+                Document document =
+                        DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+
+                assertThrows(
+                        TestFailedException.class,
+                        () ->
+                                evaluateWatchFaceForLayout(
+                                        Collections.emptyMap(),
+                                        document,
+                                        getTestEvaluationSettings()));
+            }
+        }
+
+        @Test
         public void evaluateWatchFaceForLayout_greedyEvaluationCountsTTFs() throws Exception {
             // arrange
             try (InputStream is = getClass().getResourceAsStream("/TTFFont.xml")) {

--- a/play-validations/memory-footprint/src/test/resources/MissingConfigurationDeclaration.xml
+++ b/play-validations/memory-footprint/src/test/resources/MissingConfigurationDeclaration.xml
@@ -1,0 +1,24 @@
+<WatchFace width="450" height="450" clipShape="CIRCLE">
+    <UserConfigurations>
+        <ColorConfiguration id="themeColor">
+            <ColorOption id="0" colors="#ffffffff #ffffffff #ffffffff" />
+            <ColorOption id="1" colors="#ffe7e9ec #ffe7e9ec #ffe7e9ec" />
+        </ColorConfiguration>
+    </UserConfigurations>
+    <Scene backgroundColor="#ff000000">
+        <Group x="0" y="0" width="450" height="450" name="Image2_c630" alpha="255">
+            <ListConfiguration id="c26cc07d_8aa0_47ea_8fed_db9ff00e2192">
+                <ListOption id="0">
+                    <PartImage x="0" y="0" width="450" height="450" name="Image2_c630">
+                        <Image resource="wfs_b2_b9574894_f99b_46ed_8bac_e77c72c1543b"/>
+                    </PartImage>
+                </ListOption>
+                <ListOption id="1">
+                    <PartImage x="0" y="0" width="450" height="450" name="Image2_c630">
+                        <Image resource="wfs_10_9e935b0e_0763_4121_a3d6_5a6e649c1947"/>
+                    </PartImage>
+                </ListOption>
+            </ListConfiguration>
+        </Group>
+    </Scene>
+</WatchFace>


### PR DESCRIPTION
Some watch faces might be using user configuration nodes without declaring them. These are invalid watch faces, so the code was not treating this case properly and we were getting generic exceptions. This change adds a special error message when this error happens.