### PR TITLE
Fix Text documentation

### DIFF
--- a/third_party/wff/specification/documents/1/common/attributes/alignmentAttribute.xsd
+++ b/third_party/wff/specification/documents/1/common/attributes/alignmentAttribute.xsd
@@ -20,7 +20,7 @@
     <xs:annotation>
       <xs:documentation>
         Alignment of the tag.
-        Default is START.
+        Default is CENTER.
       </xs:documentation>
     </xs:annotation>
     <xs:simpleType>

--- a/third_party/wff/specification/documents/2/common/attributes/alignmentAttribute.xsd
+++ b/third_party/wff/specification/documents/2/common/attributes/alignmentAttribute.xsd
@@ -20,7 +20,7 @@
     <xs:annotation>
       <xs:documentation>
         Alignment of the tag.
-        Default is START.
+        Default is CENTER.
       </xs:documentation>
     </xs:annotation>
     <xs:simpleType>

--- a/third_party/wff/specification/documents/3/common/attributes/alignmentAttribute.xsd
+++ b/third_party/wff/specification/documents/3/common/attributes/alignmentAttribute.xsd
@@ -20,7 +20,7 @@
     <xs:annotation>
       <xs:documentation>
         Alignment of the tag.
-        Default is START.
+        Default is CENTER.
       </xs:documentation>
     </xs:annotation>
     <xs:simpleType>

--- a/third_party/wff/specification/documents/4/common/attributes/alignmentAttribute.xsd
+++ b/third_party/wff/specification/documents/4/common/attributes/alignmentAttribute.xsd
@@ -20,7 +20,7 @@
     <xs:annotation>
       <xs:documentation>
         Alignment of the tag.
-        Default is START.
+        Default is CENTER.
       </xs:documentation>
     </xs:annotation>
     <xs:simpleType>


### PR DESCRIPTION
The default set by the XSD and set by DAC: https://developer.android.com/reference/wear-os/wff/group/part/text/text?version=4#attributes is CENTER, not START