### PR TITLE
Fix raster exception from malformed WebP images

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/DrawableResourceDetails.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/DrawableResourceDetails.java
@@ -150,7 +150,8 @@ class DrawableResourceDetails {
         }
 
         ImageProcessor.ImageReader reader =
-                imageProcessor.createImageReader(new ByteArrayInputStream(resource.getData()));
+                imageProcessor.createImageReader(
+                        new ByteArrayInputStream(resource.getData()), resource.getResourceName());
 
         if (reader == null) {
             return Optional.empty();

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ImageProcessor.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ImageProcessor.kt
@@ -38,5 +38,5 @@ interface ImageProcessor {
      *
      * @param stream The input stream of the image data.
      */
-    fun createImageReader(stream: InputStream): ImageReader?
+    fun createImageReader(stream: InputStream, imageName: String): ImageReader?
 }

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/JvmImageProcessor.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/JvmImageProcessor.kt
@@ -5,8 +5,11 @@ import java.io.InputStream
 import javax.imageio.ImageIO
 
 /** JVM-specific implementation of ImageProcessor using AWT and ImageIO. */
-class JvmImageProcessor : ImageProcessor {
-    override fun createImageReader(stream: InputStream): ImageProcessor.ImageReader? {
+class JvmImageProcessor(private val evaluationSettings: EvaluationSettings) : ImageProcessor {
+    override fun createImageReader(
+        stream: InputStream,
+        imageName: String,
+    ): ImageProcessor.ImageReader? {
         val imageInputStream = ImageIO.createImageInputStream(stream)
         val imageReaders = ImageIO.getImageReaders(imageInputStream)
 
@@ -25,15 +28,26 @@ class JvmImageProcessor : ImageProcessor {
             override val numImages: Int = reader.getNumImages(true)
 
             override fun read(imageIndex: Int): ImageData {
-                val bufferedImage = reader.read(imageIndex)
+                val bufferedImage = try {
+                    reader.read(imageIndex)
+                } catch (_: NullPointerException) {
+                    // The ImageIO WebP plug in throws a NPE when parsing a webp that is malformed,
+                    // but android can recover and render the image. In that case, we switch to an
+                    // overestimated ImageData object, representing a full white image
+                    if (evaluationSettings.verbose) {
+                        println("Failed parsing image resource $imageName. This may lead to an overestimated memory footprint.")
+                    }
+                    null
+                }
 
                 return object : ImageData {
-                    override val width: Int = bufferedImage.width
+                    override val width: Int = bufferedImage?.width ?: reader.getWidth(imageIndex)
 
-                    override val height: Int = bufferedImage.height
+                    override val height: Int = bufferedImage?.height ?: reader.getHeight(imageIndex)
 
                     override fun getRgb(x: Int, y: Int): Int {
-                        return bufferedImage.getRGB(x, y)
+                        // -1 corresponds to a full white pixel
+                        return bufferedImage?.getRGB(x, y) ?: -1
                     }
                 }
             }

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/ResourceMemoryEvaluator.java
@@ -116,7 +116,7 @@ public class ResourceMemoryEvaluator {
                     WatchFaceData.fromResourcesStream(
                             inputPackage.getWatchFaceFiles(),
                             evaluationSettings,
-                            new JvmImageProcessor());
+                            new JvmImageProcessor(evaluationSettings));
 
             if (!evaluationSettings.isHoneyfaceMode()) {
                 String wffVersion =

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/DrawableResourceDetailsTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/DrawableResourceDetailsTest.java
@@ -37,7 +37,8 @@ public class DrawableResourceDetailsTest {
                     .setCanUseRGB565(true)
                     .build();
 
-    private static final ImageProcessor imageProcessor = new JvmImageProcessor();
+    private static final ImageProcessor imageProcessor =
+            new JvmImageProcessor(new EvaluationSettings(""));
 
     @Test
     public void fromPackageFile_parsesTtfWithExtension() throws Exception {

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/WatchFaceDataTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/WatchFaceDataTest.java
@@ -56,7 +56,8 @@ public class WatchFaceDataTest {
                             .setNumberOfImages(1)
                             .build());
 
-    private static final ImageProcessor imageProcessor = new JvmImageProcessor();
+    private static final ImageProcessor imageProcessor =
+            new JvmImageProcessor(TEST_EVALUATION_SETTINGS);
 
     @Test
     public void fromResourcesStream_createsPackageFromLinuxPaths() {


### PR DESCRIPTION
Some WebP images cannot be parsed by the ImageIO plug in. They probably have a malformed frame header, but the actual rendering algorithm handles this issue gracefully and can still draw the images. Howerver, the memory footprint tool crashes for such images. When such an exception occurs, we can avoid crashing by assuming the frame is fully white, which may lead to a bigger memory footprint, but the watch face may still pass the check, or fail with a known error.