### PR TITLE
Resovle the wff format version from manifests

### DIFF
--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidManifest.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidManifest.kt
@@ -2,6 +2,7 @@ package com.google.wear.watchface.dfx.memory
 
 import com.android.aapt.Resources
 import com.android.aapt.Resources.XmlNode
+import com.google.devrel.gmscore.tools.apk.arsc.ResourceTableChunk
 import fr.xgouchet.axml.CompressedXmlParser
 import org.w3c.dom.Document
 import java.io.ByteArrayInputStream
@@ -33,6 +34,15 @@ class AndroidManifest private constructor(
         private fun Resources.XmlElement.getAndroidAttribute(attrName: String) =
             attributeList.firstOrNull { it.name == attrName && it.namespaceUri == "http://schemas.android.com/apk/res/android" }?.value
 
+        private fun Resources.XmlElement.findChild(name: String): Resources.XmlElement? =
+            childList.firstOrNull { it.element.name == name }?.element
+
+        private fun Resources.XmlElement.findProperty(propertyName: String): Resources.XmlElement? =
+            childList.asSequence()
+                .filter { it.element.name == "property" }
+                .map { it.element }
+                .firstOrNull { it.getAndroidAttribute("name") == propertyName }
+
         @JvmStatic
         fun loadFromAab(zipFile: ZipFile): AndroidManifest {
             val baseManifestEntry = zipFile.entries().asSequence()
@@ -41,28 +51,33 @@ class AndroidManifest private constructor(
                 XmlNode.parseFrom(it)
             }
 
-            val usesSdkNode =
-                manifestXmlNode.element.childList.firstOrNull { it.element.name == "uses-sdk" }?.element
-            val minSdk = usesSdkNode?.getAndroidAttribute("minSdkVersion")?.toIntOrNull() ?: 1
-            val targetSdkVersion =
-                usesSdkNode?.getAndroidAttribute("targetSdkVersion")?.toIntOrNull() ?: minSdk
-
-            val wffVersion =
-                manifestXmlNode
-                    .element
-                    .childList
-                    .firstOrNull { it.element.name == "application" }
-                    ?.element
-                    ?.childList
-                    ?.firstOrNull {
-                        it.element.name == "property" && it.element.getAndroidAttribute("name") == DWF_PROPERTY_NAME
-                    }?.element
-                    ?.getAndroidAttribute("value")
-                    ?.toIntOrNull()
-
-            requireNotNull(wffVersion) {
-                "Watch Face Manifest must have a property with name \"$DWF_PROPERTY_NAME\" that specifies the version of the Watch Face Format to be used."
+            // Load resources.pb if present
+            val resourcesEntry = zipFile.entries().asSequence()
+                .firstOrNull { it.name.endsWith("resources.pb") }
+            val resourceTable: Resources.ResourceTable? = resourcesEntry?.let { entry ->
+                zipFile.getInputStream(entry).use { stream ->
+                    Resources.ResourceTable.parseFrom(stream)
+                }
             }
+
+            val rootElement = manifestXmlNode.element
+            val usesSdkNode = rootElement.findChild("uses-sdk")
+
+            val minSdkStr = usesSdkNode?.getAndroidAttribute("minSdkVersion") ?: "1"
+            val minSdk = AndroidResourceResolver.resolveProtoAttribute(resourceTable, minSdkStr).toIntOrNull() ?: 1
+
+            val targetSdkStr = usesSdkNode?.getAndroidAttribute("targetSdkVersion") ?: minSdkStr
+            val targetSdkVersion = AndroidResourceResolver.resolveProtoAttribute(resourceTable, targetSdkStr).toIntOrNull() ?: minSdk
+
+            val wffVersionStr = rootElement.findChild("application")
+                ?.findProperty(DWF_PROPERTY_NAME)
+                ?.getAndroidAttribute("value")
+                ?: throw java.lang.RuntimeException("Watch Face Manifest must specify format version")
+
+            val resolvedWffVersion = AndroidResourceResolver.resolveProtoAttribute(resourceTable, wffVersionStr)
+            val wffVersion = resolvedWffVersion.toIntOrNull()
+                ?: throw NumberFormatException("Failed to parse wffVersion: '$resolvedWffVersion'")
+
             return AndroidManifest(
                 wffVersion = wffVersion,
                 minSdkVersion = minSdk,
@@ -71,16 +86,19 @@ class AndroidManifest private constructor(
         }
 
         @JvmStatic
-        private fun loadFromBinaryXml(inputStream: InputStream): AndroidManifest {
+        private fun loadFromBinaryXml(
+            inputStream: InputStream,
+            resourceTable: ResourceTableChunk? = null,
+        ): AndroidManifest {
             // the axml loads into memory only the inputStream.available() bytes, so the manifest bytes must be fully
             // loaded into memory for parsing to work
             val buffer = inputStream.readBytes()
             val doc = CompressedXmlParser().parseDOM(ByteArrayInputStream(buffer))
-            return loadFromDocument(doc)
+            return loadFromDocument(doc, resourceTable)
         }
 
         @JvmStatic
-        private fun loadFromPlainXml(bytes: ByteArray): AndroidManifest {
+        private fun loadFromPlainXml(bytes: ByteArray, resDir: Path? = null): AndroidManifest {
             val factory = DocumentBuilderFactory.newInstance()
             factory.isValidating = false
             factory.isNamespaceAware = true
@@ -88,15 +106,32 @@ class AndroidManifest private constructor(
             val docBuilder = factory.newDocumentBuilder()
 
             val doc = docBuilder.parse(ByteArrayInputStream(bytes))
-            return loadFromDocument(doc)
+            return loadFromDocument(doc, resDir = resDir)
+        }
+
+        private fun getResolvedAttribute(
+            doc: Document,
+            pathSpec: String,
+            resourceTable: ResourceTableChunk?,
+            resDir: Path?
+        ): String? {
+            val rawValue = getAttribute(doc, pathSpec)
+            return AndroidResourceResolver.resolveAttributeValue(rawValue, resourceTable, resDir)
         }
 
         @JvmStatic
-        private fun loadFromDocument(doc: Document): AndroidManifest {
-            val minSdk = getAttribute(doc, "//uses-sdk/@android:minSdkVersion").toIntOrNull() ?: 1
-            val targetSdk =
-                getAttribute(doc, "//uses-sdk/@android:targetSdkVersion").toIntOrNull() ?: minSdk
-            val wffVersion = getAttribute(doc, WFF_VERSION_PROP_NAME).toInt()
+        internal fun loadFromDocument(
+            doc: Document,
+            resourceTable: ResourceTableChunk? = null,
+            resDir: Path? = null,
+        ): AndroidManifest {
+            val minSdk = getResolvedAttribute(doc, "//uses-sdk/@android:minSdkVersion", resourceTable, resDir)
+                ?.toIntOrNull() ?: 1
+            val targetSdk = getResolvedAttribute(doc, "//uses-sdk/@android:targetSdkVersion", resourceTable, resDir)
+                ?.toIntOrNull() ?: minSdk
+            val resolvedWffVersion = getResolvedAttribute(doc, WFF_VERSION_PROP_NAME, resourceTable, resDir)
+            val wffVersion = resolvedWffVersion?.toIntOrNull()
+                ?: throw NumberFormatException("Failed to parse wffVersion: '$resolvedWffVersion'")
             return AndroidManifest(wffVersion, minSdk, targetSdk)
         }
 
@@ -108,27 +143,45 @@ class AndroidManifest private constructor(
                 .get()
 
             val inputStream = zipFile.getInputStream(manifestEntry)
-            return loadFromBinaryXml(inputStream)
+            val resourcesEntry = zipFile.getEntry("resources.arsc")
+            val resourceTable = resourcesEntry?.let { entry ->
+                zipFile.getInputStream(entry).use { stream ->
+                    AndroidResourceLoader.loadResourceTable(stream)
+                }
+            }
+            return loadFromBinaryXml(inputStream, resourceTable)
         }
 
         @JvmStatic
         fun loadFromAabDirectory(aabPath: Path): AndroidManifest? {
             val childrenFiles = aabPath.toFile().walk()
-            val manifestFile = childrenFiles
-                .filter { p -> p.toPath().endsWith(ANDROID_MANIFEST_FILE_NAME) }.firstOrNull()
-            return manifestFile?.let { loadFromPlainXml(it.readBytes()) }
+            val manifestFile =
+                childrenFiles.firstOrNull { p -> p.toPath().endsWith(ANDROID_MANIFEST_FILE_NAME) }
+                    ?: return null
+            val resDir = manifestFile.toPath().parent.parent.resolve("res")
+            return loadFromPlainXml(manifestFile.readBytes(), resDir)
         }
 
         @JvmStatic
         fun loadFromMokkaZip(baseSplitZipStream: ZipInputStream): AndroidManifest {
+            var manifestBytes: ByteArray? = null
+            var resourcesBytes: ByteArray? = null
             var entry = baseSplitZipStream.nextEntry
             while (entry != null) {
                 if (entry.name.endsWith(ANDROID_MANIFEST_FILE_NAME)) {
-                    return loadFromBinaryXml(baseSplitZipStream)
+                    manifestBytes = baseSplitZipStream.readBytes()
+                } else if (entry.name.endsWith("resources.arsc")) {
+                    resourcesBytes = baseSplitZipStream.readBytes()
                 }
                 entry = baseSplitZipStream.nextEntry
             }
-            throw java.lang.RuntimeException("Android Manifest not found")
+            if (manifestBytes == null) {
+                throw java.lang.RuntimeException("Android Manifest not found")
+            }
+            val resourceTable = resourcesBytes?.let { bytes ->
+                AndroidResourceLoader.loadResourceTable(ByteArrayInputStream(bytes))
+            }
+            return loadFromBinaryXml(ByteArrayInputStream(manifestBytes), resourceTable)
         }
 
         private fun getAttribute(doc: Document, pathSpec: String): String {

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceLoader.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceLoader.kt
@@ -108,17 +108,7 @@ object AndroidResourceLoader {
     fun streamFromApkFile(apkFile: ZipFile): Sequence<AndroidResource> {
         val arscEntry = ZipEntry(RESOURCES_FILE_NAME)
 
-        val resources =
-            apkFile.getInputStream(arscEntry).use { BinaryResourceFile.fromInputStream(it) }
-
-        val chunks = resources.chunks
-        if (chunks.isEmpty()) {
-            throw IOException("no chunks")
-        }
-        if (chunks[0] !is ResourceTableChunk) {
-            throw IOException("no res table chunk")
-        }
-        val table = chunks[0] as ResourceTableChunk
+        val table = apkFile.getInputStream(arscEntry).use { loadResourceTable(it) }
         val stringPool = table.stringPool
 
         val typeChunks = table.packages.asSequence().flatMap { it.typeChunks }
@@ -138,6 +128,16 @@ object AndroidResourceLoader {
                     data
                 )
             }
+    }
+
+    @JvmStatic
+    fun loadResourceTable(inputStream: InputStream): ResourceTableChunk {
+        val resources = BinaryResourceFile.fromInputStream(inputStream)
+        val chunks = resources.chunks
+        if (chunks.isEmpty() || chunks[0] !is ResourceTableChunk) {
+            throw IOException("no res table chunk")
+        }
+        return chunks[0] as ResourceTableChunk
     }
 
     @JvmStatic

--- a/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceResolver.kt
+++ b/play-validations/memory-footprint/src/main/java/com/google/wear/watchface/dfx/memory/AndroidResourceResolver.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.wear.watchface.dfx.memory
+
+import com.android.aapt.Resources
+import com.google.devrel.gmscore.tools.apk.arsc.BinaryResourceValue
+import com.google.devrel.gmscore.tools.apk.arsc.ResourceTableChunk
+import java.nio.file.Path
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Utility for resolving Android resource references across various package formats
+ * (binary XML/ARSC, protobuf/AAB, and plain XML directories).
+ */
+object AndroidResourceResolver {
+
+    @JvmStatic
+    fun parseResourceId(value: String): Int? {
+        if (!value.startsWith("@")) return null
+        
+        var cleanValue = value.substring(1)
+        val colonIdx = cleanValue.indexOf(':')
+        if (colonIdx != -1) {
+            cleanValue = cleanValue.substring(colonIdx + 1)
+        }
+
+        val hexIdx = cleanValue.indexOf("0x", ignoreCase = true)
+        if (hexIdx != -1) {
+            val hexStr = cleanValue.substring(hexIdx + 2)
+            return try {
+                hexStr.toLong(16).toInt()
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        if (cleanValue.all { it.isDigit() }) {
+            return try {
+                cleanValue.toLong().toInt()
+            } catch (e: NumberFormatException) {
+                null
+            }
+        }
+
+        return null
+    }
+
+    @JvmStatic
+    fun resolveResourceValue(resourceTable: ResourceTableChunk, resourceId: Int): String {
+        return resolveResourceValue(resourceTable, resourceId, emptySet())
+    }
+
+    private fun resolveResourceValue(
+        resourceTable: ResourceTableChunk,
+        resourceId: Int,
+        visited: Set<Int>
+    ): String {
+        if (visited.contains(resourceId)) {
+            throw java.lang.RuntimeException("Cyclic resource reference detected for ID $resourceId")
+        }
+        val packageId = (resourceId ushr 24) and 0xFF
+        val typeId = (resourceId ushr 16) and 0xFF
+        val entryId = resourceId and 0xFFFF
+
+        val pkg = resourceTable.packages.firstOrNull { it.id == packageId }
+            ?: throw java.lang.RuntimeException("Package not found for ID $packageId")
+
+        val typeChunks = pkg.typeChunks.filter { it.id == typeId }
+        if (typeChunks.isEmpty()) {
+            throw java.lang.RuntimeException("Type not found for ID $typeId")
+        }
+
+        val newVisited = visited + resourceId
+
+        for (typeChunk in typeChunks) {
+            val entry = typeChunk.entries[entryId]
+            if (entry != null) {
+                val value = entry.value()
+                if (value != null) {
+                    if (value.type() == BinaryResourceValue.Type.INT_DEC ||
+                        value.type() == BinaryResourceValue.Type.INT_HEX) {
+                        return value.data().toString()
+                    } else if (value.type() == BinaryResourceValue.Type.STRING) {
+                        return resourceTable.stringPool.getString(value.data())
+                    } else if (value.type() == BinaryResourceValue.Type.REFERENCE ||
+                               value.type() == BinaryResourceValue.Type.DYNAMIC_REFERENCE) {
+                        return resolveResourceValue(resourceTable, value.data(), newVisited)
+                    } else {
+                        throw java.lang.RuntimeException("Unsupported resource value type: ${value.type()}")
+                    }
+                }
+            }
+        }
+        throw java.lang.RuntimeException("Entry not found for ID $entryId")
+    }
+
+    @JvmStatic
+    fun resolveProtoResource(resourceTable: Resources.ResourceTable, ref: String): String {
+        if (!ref.startsWith("@")) return ref
+        val parts = ref.substring(1).split("/")
+        if (parts.size != 2) return ref
+        val resType = parts[0]
+        val resName = parts[1]
+
+        for (pkg in resourceTable.packageList) {
+            val type = pkg.typeList.firstOrNull { it.name == resType } ?: continue
+            val entry = type.entryList.firstOrNull { it.name == resName } ?: continue
+            val configValue = entry.configValueList.firstOrNull() ?: continue
+            val value = configValue.value
+            if (value.hasItem()) {
+                val item = value.item
+                if (item.hasPrim()) {
+                    val prim = item.prim
+                    return when {
+                        prim.hasIntDecimalValue() -> prim.intDecimalValue.toString()
+                        prim.hasIntHexadecimalValue() -> prim.intHexadecimalValue.toString()
+                        prim.hasBooleanValue() -> prim.booleanValue.toString()
+                        else -> ref
+                    }
+                } else if (item.hasStr()) {
+                    return item.str.value
+                }
+            }
+        }
+        return ref
+    }
+    @JvmStatic
+    fun resolveProtoAttribute(resourceTable: Resources.ResourceTable?, value: String): String {
+        if (resourceTable == null) return value
+        return resolveProtoResource(resourceTable, value)
+    }
+    @JvmStatic
+    fun resolvePlainXmlResource(resDir: Path, ref: String): String {
+        if (!ref.startsWith("@")) return ref
+        val parts = ref.substring(1).split("/")
+        if (parts.size != 2) return ref
+        val resType = parts[0]
+        val resName = parts[1]
+
+        val valuesDir = resDir.resolve("values")
+        if (!java.nio.file.Files.exists(valuesDir)) return ref
+
+        val files = valuesDir.toFile().listFiles { f -> f.extension == "xml" } ?: return ref
+        for (file in files) {
+            try {
+                val factory = DocumentBuilderFactory.newInstance()
+                val builder = factory.newDocumentBuilder()
+                val doc = builder.parse(file)
+                val nodes = doc.getElementsByTagName(resType)
+                for (i in 0 until nodes.length) {
+                    val node = nodes.item(i) as org.w3c.dom.Element
+                    if (node.getAttribute("name") == resName) {
+                        return node.textContent.trim()
+                    }
+                }
+            } catch (e: Exception) {
+                // ignore
+            }
+        }
+        return ref
+    }
+
+    @JvmStatic
+    fun resolveAttributeValue(
+        value: String,
+        resourceTable: ResourceTableChunk?,
+        resDir: Path?
+    ): String? {
+        if (value.isEmpty()) return null
+        if (!value.startsWith("@")) return value
+
+        if (resourceTable != null) {
+            val resourceId = parseResourceId(value) ?: return value
+            return try {
+                resolveResourceValue(resourceTable, resourceId)
+            } catch (e: Exception) {
+                value
+            }
+        }
+
+        if (resDir != null) {
+            return try {
+                resolvePlainXmlResource(resDir, value)
+            } catch (e: Exception) {
+                value
+            }
+        }
+
+        return value
+    }
+}

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AndroidManifestTest.kt
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/AndroidManifestTest.kt
@@ -83,4 +83,58 @@ class AndroidManifestTest {
         assertThat(manifest.minSdkVersion).isEqualTo(33)
         assertThat(manifest.targetSdkVersion).isEqualTo(33)
     }
+    @Test
+    fun loadFromDocument_resolvesResourceReference() {
+        val apkZip = ZipFile(Path.of(SAMPLE_WF_BASE_ARTIFACTS_PATH, "apk/release/sample-wf-release.apk").toFile())
+        val arscEntry = apkZip.getEntry("resources.arsc")
+        val arscBytes = apkZip.getInputStream(arscEntry).use { it.readBytes() }
+        val resourceTable = AndroidResourceLoader.loadResourceTable(java.io.ByteArrayInputStream(arscBytes))
+
+        val appNameResId = getResourceId(resourceTable, "string", "app_name")
+        val appNameHex = "0x" + Integer.toHexString(appNameResId).uppercase()
+
+        val factory = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        factory.isNamespaceAware = true
+        val builder = factory.newDocumentBuilder()
+        val doc = builder.newDocument()
+        
+        val manifest = doc.createElement("manifest")
+        manifest.setAttribute("xmlns:android", "http://schemas.android.com/apk/res/android")
+        doc.appendChild(manifest)
+        
+        val usesSdk = doc.createElement("uses-sdk")
+        usesSdk.setAttributeNS("http://schemas.android.com/apk/res/android", "android:minSdkVersion", "33")
+        usesSdk.setAttributeNS("http://schemas.android.com/apk/res/android", "android:targetSdkVersion", "33")
+        manifest.appendChild(usesSdk)
+        
+        val application = doc.createElement("application")
+        manifest.appendChild(application)
+        
+        val property = doc.createElement("property")
+        property.setAttributeNS("http://schemas.android.com/apk/res/android", "android:name", "com.google.wear.watchface.format.version")
+        property.setAttributeNS("http://schemas.android.com/apk/res/android", "android:value", "@id/$appNameHex")
+        application.appendChild(property)
+        
+        try {
+            AndroidManifest.loadFromDocument(doc, resourceTable)
+            org.junit.Assert.fail("Expected NumberFormatException")
+        } catch (e: NumberFormatException) {
+            assertThat(e.message).contains("Failed to parse wffVersion: 'MemorySample'")
+        }
+    }
+
+    private fun getResourceId(table: com.google.devrel.gmscore.tools.apk.arsc.ResourceTableChunk, typeName: String, entryName: String): Int {
+        for (pkg in table.packages) {
+            for (typeChunk in pkg.typeChunks) {
+                if (typeChunk.typeName == typeName) {
+                    for ((entryId, entry) in typeChunk.entries) {
+                        if (entry.key() == entryName) {
+                            return (pkg.id shl 24) or (typeChunk.id shl 16) or entryId
+                        }
+                    }
+                }
+            }
+        }
+        throw RuntimeException("Resource not found: $typeName/$entryName")
+    }
 }

--- a/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/InputPackageTest.java
+++ b/play-validations/memory-footprint/src/test/java/com/google/wear/watchface/dfx/memory/InputPackageTest.java
@@ -72,6 +72,7 @@ public class InputPackageTest {
                         "base/res/font/open_sans_regular.ttf",
                         "base/res/raw/watchface.xml",
                         "base/res/values/strings.xml",
+                        "base/res/values/integers.xml",
                         "base/res/xml/watch_face_info.xml",
                         "base/manifest/AndroidManifest.xml");
 

--- a/play-validations/memory-footprint/test-samples/sample-wf/src/main/AndroidManifest.xml
+++ b/play-validations/memory-footprint/test-samples/sample-wf/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <application android:hasCode="false" android:label="@string/app_name">
         <property
             android:name="com.google.wear.watchface.format.version"
-            android:value="1" />
+            android:value="@integer/wff_version" />
     </application>
 
 </manifest>

--- a/play-validations/memory-footprint/test-samples/sample-wf/src/main/res/values/integers.xml
+++ b/play-validations/memory-footprint/test-samples/sample-wf/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="wff_version">1</integer>
+</resources>


### PR DESCRIPTION
The WFF version in manifests may be an int reference, not a hardcoded integer. This was not accounted for before. This change parses the resource table, from an arsc file or from a pb file, and resolves attributes.